### PR TITLE
Webclient improvements

### DIFF
--- a/APISPEC.md
+++ b/APISPEC.md
@@ -1,7 +1,7 @@
 - POST /session
     - Start the session and fetch sessionToken, providing username
 - GET /match
-    - Begin matching, receive color when match is found
+    - Begin matching, receive color when match is found, otherwise HTTP 202
 - POST /sync
     - Make a move, receive 200 if move is succesful, 400 otherwise
 - POST /async

--- a/APISPEC.md
+++ b/APISPEC.md
@@ -7,10 +7,10 @@
 - POST /async
     - Make an async request (draw/resign) receive 200 if request received
 - GET /async
-    - Get any async updates (should be constantly polling this endpoint)
+    - Get any async updates (should be constantly polling this endpoint), returns HTTP 204 if no update after server timeout
         - gameOver, requestToDraw, gameOver results
 - GET /sync
-    - Get opponents move (should query this after a succesful move)
+    - Get opponents move (should query this after a succesful move), returns HTTP 204 if no update after server timeout
 - GET /currentgame
     - Get the state of the board (call this to check if in a game and to get the state of it if so)
     - Return 404 if not in a game, 200 with state otherwise

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ TODO
         - [x] testing
 * Client
     - [ ] Golang WebAssembly web client
-        - [ ] Show "pending draw" when requesting a draw
+        - [x] Show "pending draw" when requesting a draw
         - [ ] Handle 200 response from GET sync with no update
         - [x] Display matched opponent name
         - [ ] Check cookies for session token instead of using hasSession bool

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ TODO
         Just need a hash function to go from position -> positionId
 * Server
     - [x] http server
+      - [ ] Instead of hanging on GET sync, return immediately with no update
+      - [ ] Instead of hanging on GET match, return after 2 seconds so that we can have tighter timeouts
       - [ ] If no response from client in x seconds then call disconnect win for opponent
       - [ ] Support some mechanism for a user cancelling their matchmaking
       - [ ] GET /sync should also provide player and opponent's remaining time to keep client, server in sync
@@ -31,6 +33,8 @@ TODO
         - [x] testing
 * Client
     - [ ] Golang WebAssembly web client
+        - [ ] Show "pending draw" when requesting a draw
+        - [ ] Handle 200 response from GET sync with no update
         - [x] Display matched opponent name
         - [ ] Check cookies for session token instead of using hasSession bool
             - Not sure if possible, the golang cookiejar doesn't seem like it supports this.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ TODO
         Just need a hash function to go from position -> positionId
 * Server
     - [x] http server
-      - [ ] Instead of hanging on GET sync/async, return immediately with no update
-      - [x] Instead of hanging on GET match, return after 2 seconds so that we can have tighter timeouts
+      - [ ] Make a websocket server/client as an alternative to long polling
+      - [x] Instead of hanging indefinitely on GET sync/async, return with no update after timeout
+      - [x] Instead of hanging indefinitely on GET match, return after a server timeout with http 204
       - [ ] If no response from client in x seconds then call disconnect win for opponent
       - [ ] Support some mechanism for a user cancelling their matchmaking
       - [ ] GET /sync should also provide player and opponent's remaining time to keep client, server in sync
@@ -35,7 +36,7 @@ TODO
     - [ ] Golang WebAssembly web client
         - [x] Show "pending draw" when requesting a draw
         - [x] Handle 202 responses from GET match while still pending
-        - [ ] Handle 200 response from GET sync/async with no update
+        - [x] Handle 200 response from GET sync/async with no update
         - [x] Display matched opponent name
         - [ ] Check cookies for session token instead of using hasSession bool
             - Not sure if possible, the golang cookiejar doesn't seem like it supports this.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ TODO
         - [x] Display matched opponent name
         - [ ] Check cookies for session token instead of using hasSession bool
             - Not sure if possible, the golang cookiejar doesn't seem like it supports this.
-        - [ ] Display gameover results
+        - [x] Display gameover results
         - [x] Request a draw/resign
         - [x] Display remaining time
         - [x] Display point advantage/captured pieces

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TODO
         Just need a hash function to go from position -> positionId
 * Server
     - [x] http server
-      - [ ] Instead of hanging on GET sync, return immediately with no update
+      - [ ] Instead of hanging on GET sync/async, return immediately with no update
       - [ ] Instead of hanging on GET match, return after 2 seconds so that we can have tighter timeouts
       - [ ] If no response from client in x seconds then call disconnect win for opponent
       - [ ] Support some mechanism for a user cancelling their matchmaking
@@ -34,7 +34,7 @@ TODO
 * Client
     - [ ] Golang WebAssembly web client
         - [x] Show "pending draw" when requesting a draw
-        - [ ] Handle 200 response from GET sync with no update
+        - [ ] Handle 200 response from GET sync/async with no update
         - [x] Display matched opponent name
         - [ ] Check cookies for session token instead of using hasSession bool
             - Not sure if possible, the golang cookiejar doesn't seem like it supports this.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TODO
         Just need a hash function to go from position -> positionId
 * Server
     - [x] http server
-      - [ ] Make a websocket server/client as an alternative to long polling
+      - [ ] Make a websocket server/client as an alternative to polling
       - [x] Instead of hanging indefinitely on GET sync/async, return with no update after timeout
       - [x] Instead of hanging indefinitely on GET match, return after a server timeout with http 204
       - [ ] If no response from client in x seconds then call disconnect win for opponent

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ TODO
 * Server
     - [x] http server
       - [ ] Instead of hanging on GET sync/async, return immediately with no update
-      - [ ] Instead of hanging on GET match, return after 2 seconds so that we can have tighter timeouts
+      - [x] Instead of hanging on GET match, return after 2 seconds so that we can have tighter timeouts
       - [ ] If no response from client in x seconds then call disconnect win for opponent
       - [ ] Support some mechanism for a user cancelling their matchmaking
       - [ ] GET /sync should also provide player and opponent's remaining time to keep client, server in sync
@@ -34,6 +34,7 @@ TODO
 * Client
     - [ ] Golang WebAssembly web client
         - [x] Show "pending draw" when requesting a draw
+        - [x] Handle 202 responses from GET match while still pending
         - [ ] Handle 200 response from GET sync/async with no update
         - [x] Display matched opponent name
         - [ ] Check cookies for session token instead of using hasSession bool

--- a/cmd/webserver/assets/index.html
+++ b/cmd/webserver/assets/index.html
@@ -83,7 +83,7 @@ license that can be found in the LICENSE file.
             gap: 10px;
             grid-auto-rows: minmax(10px, auto);
         }
-        // As per https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout
+        /* As per https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout */
         .matchdetails_opponent_name {
             grid-column: 1;
             grid-row: 1;
@@ -117,7 +117,45 @@ license that can be found in the LICENSE file.
             grid-row: 4;
         }
         .hidden {
-            visibility: hidden;
+            display: none;
+        }
+
+        /* As per https://www.w3schools.com/howto/howto_css_modals.asp */
+        .gameover_modal {
+            display: block;
+            position: fixed; /* Stay in place */
+            z-index: 1; /* Sit on top */
+            left: 0;
+            top: 0;
+            width: 100%; /* Full width */
+            height: 100%; /* Full height */
+            overflow: auto; /* Enable scroll if needed */
+            background-color: rgb(0,0,0); /* Fallback color */
+            background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+        }
+
+        /* Modal Content/Box */
+        .gameover_modal_content {
+            background-color: #fefefe;
+            margin: 15% auto; /* 15% from the top and centered */
+            padding: 20px;
+            border: 1px solid #888;
+            width: 80%; /* Could be more or less, depending on screen size */
+        }
+
+        /* The Close Button */
+        .close {
+            color: #aaa;
+            float: right;
+            font-size: 28px;
+            font-weight: bold;
+        }
+
+        .close:hover,
+        .close:focus {
+            color: black;
+            text-decoration: none;
+            cursor: pointer;
         }
 
         @keyframes spin {
@@ -149,6 +187,13 @@ license that can be found in the LICENSE file.
 
 
     <div class="wrapper">
+        <div id="gameover_modal" class="hidden">
+            <!-- Modal content -->
+            <div class="gameover_modal_content">
+                <span id="gameover_modal_close" class="close">&times;</span>
+                <p id="gameover_modal_text"/>
+            </div>
+        </div>
         <h3 id="matchdetails_opponent_name" class="matchdetails_opponent_name"></h3>
         <h3 id="matchdetails_opponent_remainingtime" class="matchdetails_opponent_remainingtime"></h3>
         <h3 id="matchdetails_opponent_points" class="matchdetails_opponent_points"></h3>

--- a/internal/model/piece.go
+++ b/internal/model/piece.go
@@ -104,8 +104,7 @@ func (piece *Piece) Value() int8 {
 		return 9
 	case Rook:
 		return 5
-	case Knight:
-	case Bishop:
+	case Knight, Bishop:
 		return 3
 	case Pawn:
 		return 1

--- a/internal/server/http/webclient/main.go
+++ b/internal/server/http/webclient/main.go
@@ -7,13 +7,15 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"syscall/js"
+	"time"
 )
 
 func main() {
 	done := make(chan struct{}, 0)
 	game := model.NewGame()
 	jar, _ := cookiejar.New(&cookiejar.Options{})
-	client := &http.Client{Jar: jar}
+	clientTimeout, _ := time.ParseDuration("60s")
+	client := &http.Client{Jar: jar, Timeout: clientTimeout}
 	clientModel := ClientModel{
 		game: &game, playerColor: model.White,
 		document: js.Global().Get("document"),

--- a/internal/server/http/webclient/main.go
+++ b/internal/server/http/webclient/main.go
@@ -14,7 +14,7 @@ func main() {
 	done := make(chan struct{}, 0)
 	game := model.NewGame()
 	jar, _ := cookiejar.New(&cookiejar.Options{})
-	clientTimeout, _ := time.ParseDuration("60s")
+	clientTimeout, _ := time.ParseDuration("15s")
 	client := &http.Client{Jar: jar, Timeout: clientTimeout}
 	clientModel := ClientModel{
 		game: &game, playerColor: model.White,

--- a/internal/server/http/webclient/webclient.go
+++ b/internal/server/http/webclient/webclient.go
@@ -47,6 +47,10 @@ type RemoteMatchModel struct {
 	endRemoteGameChan chan bool
 }
 
+func (cm *ClientModel) ResetRemoteMatchModel() {
+	cm.remoteMatchModel = RemoteMatchModel{}
+}
+
 func (cm *ClientModel) GetGameType() GameType {
 	cm.cmMutex.RLock()
 	defer cm.cmMutex.RUnlock()

--- a/internal/server/http/webclient/webclient.go
+++ b/internal/server/http/webclient/webclient.go
@@ -39,12 +39,13 @@ type ClientModel struct {
 }
 
 type RemoteMatchModel struct {
-	opponentName      string
-	maxTimeMs         int64
-	playerElapsedMs   int64
-	opponentElapsedMs int64
-	requestedDraw     bool
-	endRemoteGameChan chan bool
+	opponentName          string
+	maxTimeMs             int64
+	playerElapsedMs       int64
+	opponentElapsedMs     int64
+	opponentRequestedDraw bool
+	playerRequestedDraw   bool
+	endRemoteGameChan     chan bool
 }
 
 func (cm *ClientModel) ResetRemoteMatchModel() {
@@ -236,16 +237,31 @@ func (cm *ClientModel) AddPlayerElapsedMs(color model.Color, elapsedMs int64) {
 	}
 }
 
-func (cm *ClientModel) GetRequestedDraw() bool {
+func (cm *ClientModel) GetRequestedDraw(color model.Color) bool {
 	cm.cmMutex.RLock()
 	defer cm.cmMutex.RUnlock()
-	return cm.remoteMatchModel.requestedDraw
+	if color == cm.playerColor {
+		return cm.remoteMatchModel.playerRequestedDraw
+	} else {
+		return cm.remoteMatchModel.opponentRequestedDraw
+	}
 }
 
-func (cm *ClientModel) SetRequestedDraw(requestedDraw bool) {
+func (cm *ClientModel) ClearRequestedDraw() {
 	cm.cmMutex.Lock()
 	defer cm.cmMutex.Unlock()
-	cm.remoteMatchModel.requestedDraw = requestedDraw
+	cm.remoteMatchModel.playerRequestedDraw = false
+	cm.remoteMatchModel.opponentRequestedDraw = false
+}
+
+func (cm *ClientModel) SetRequestedDraw(color model.Color, requestedDraw bool) {
+	cm.cmMutex.Lock()
+	defer cm.cmMutex.Unlock()
+	if color == cm.playerColor {
+		cm.remoteMatchModel.playerRequestedDraw = requestedDraw
+	} else {
+		cm.remoteMatchModel.opponentRequestedDraw = requestedDraw
+	}
 }
 
 func (cm *ClientModel) GetHasSession() bool {

--- a/internal/server/http/webclient/webclient.go
+++ b/internal/server/http/webclient/webclient.go
@@ -49,6 +49,8 @@ type RemoteMatchModel struct {
 }
 
 func (cm *ClientModel) ResetRemoteMatchModel() {
+	cm.cmMutex.Lock()
+	defer cm.cmMutex.Unlock()
 	cm.remoteMatchModel = RemoteMatchModel{}
 }
 
@@ -59,8 +61,8 @@ func (cm *ClientModel) GetGameType() GameType {
 }
 
 func (cm *ClientModel) SetGameType(gameType GameType) {
-	cm.cmMutex.RLock()
-	defer cm.cmMutex.RUnlock()
+	cm.cmMutex.Lock()
+	defer cm.cmMutex.Unlock()
 	cm.gameType = gameType
 }
 
@@ -105,8 +107,8 @@ func (cm *ClientModel) GetOpponentColor() model.Color {
 }
 
 func (cm *ClientModel) SetPlayerColor(color model.Color) {
-	cm.cmMutex.RLock()
-	defer cm.cmMutex.RUnlock()
+	cm.cmMutex.Lock()
+	defer cm.cmMutex.Unlock()
 	cm.playerColor = color
 }
 

--- a/internal/server/http/webclient/webclientcontroller.go
+++ b/internal/server/http/webclient/webclientcontroller.go
@@ -214,6 +214,7 @@ func (cm *ClientModel) listenForSyncUpdate() {
 		resp, err := cm.client.Get("sync")
 		if err == nil {
 			defer resp.Body.Close()
+			retries = 0
 			opponentMove := model.MoveRequest{}
 			json.NewDecoder(resp.Body).Decode(&opponentMove)
 			err := cm.MakeMove(opponentMove)
@@ -231,6 +232,7 @@ func (cm *ClientModel) listenForSyncUpdate() {
 			elMoving := elements.Index(0)
 			cm.viewHandleMove(opponentMove, newPos, elMoving)
 		} else {
+			log.Println(err)
 			time.Sleep(500 * time.Millisecond)
 			retries++
 			if retries >= maxRetries {
@@ -257,6 +259,7 @@ func (cm *ClientModel) listenForAsyncUpdate() {
 		resp, err := cm.client.Get("async")
 		if err == nil {
 			defer resp.Body.Close()
+			retries = 0
 			asyncResponse := matchserver.ResponseAsync{}
 			json.NewDecoder(resp.Body).Decode(&asyncResponse)
 			if asyncResponse.GameOver {
@@ -280,6 +283,7 @@ func (cm *ClientModel) listenForAsyncUpdate() {
 				cm.SetRequestedDraw(!cm.GetRequestedDraw())
 			}
 		} else {
+			log.Println(err)
 			time.Sleep(500 * time.Millisecond)
 			retries++
 			if retries >= maxRetries {

--- a/internal/server/http/webclient/webclientcontroller.go
+++ b/internal/server/http/webclient/webclientcontroller.go
@@ -86,6 +86,7 @@ func (clientModel *ClientModel) closeGameoverModal() {
 	clientModel.viewClearMatchDetails()
 	clientModel.SetGameType(Local)
 	clientModel.SetIsMatched(false)
+	clientModel.ResetRemoteMatchModel()
 	clientModel.resetGame()
 }
 

--- a/internal/server/http/webclient/webclientview.go
+++ b/internal/server/http/webclient/webclientview.go
@@ -87,9 +87,11 @@ func (cm *ClientModel) viewSetMatchDetails() {
 	playerMatchDetailsRemainingTime.Set("innerText",
 		cm.formatTime(playerRemainingMs))
 	drawButtonText := "Draw"
-	if cm.GetRequestedDraw() {
+	if cm.GetRequestedDraw(cm.GetOpponentColor()) {
 		drawButtonText = fmt.Sprintf("Draw, %s requested a draw",
 			cm.remoteMatchModel.opponentName)
+	} else if cm.GetRequestedDraw(cm.GetPlayerColor()) {
+		drawButtonText = fmt.Sprintf("Draw, requesting a draw...")
 	}
 	drawButton := cm.document.Call("getElementById", "drawButton")
 	drawButton.Set("innerText", drawButtonText)

--- a/internal/server/http/webclient/webclientview.go
+++ b/internal/server/http/webclient/webclientview.go
@@ -30,16 +30,31 @@ func (clientModel *ClientModel) initStyle() {
 func (cm *ClientModel) viewSetMatchControls() {
 	usernameInput := cm.document.Call(
 		"getElementById", "username")
-	usernameInput.Call("remove")
+	addClass(usernameInput, "hidden")
 	matchButton := cm.document.Call(
 		"getElementById", "beginMatchmakingButton")
-	matchButton.Call("remove")
+	addClass(matchButton, "hidden")
 	resignButton := cm.document.Call(
 		"getElementById", "resignButton")
 	removeClass(resignButton, "hidden")
 	drawButton := cm.document.Call(
 		"getElementById", "drawButton")
 	removeClass(drawButton, "hidden")
+}
+
+func (cm *ClientModel) viewSetMatchMakingControls() {
+	usernameInput := cm.document.Call(
+		"getElementById", "username")
+	removeClass(usernameInput, "hidden")
+	matchButton := cm.document.Call(
+		"getElementById", "beginMatchmakingButton")
+	removeClass(matchButton, "hidden")
+	resignButton := cm.document.Call(
+		"getElementById", "resignButton")
+	addClass(resignButton, "hidden")
+	drawButton := cm.document.Call(
+		"getElementById", "drawButton")
+	addClass(drawButton, "hidden")
 }
 
 func (cm *ClientModel) viewSetMatchDetails() {
@@ -80,6 +95,21 @@ func (cm *ClientModel) viewSetMatchDetails() {
 	drawButton.Set("innerText", drawButtonText)
 }
 
+func (cm *ClientModel) viewClearMatchDetails() {
+	cm.document.Call("getElementById",
+		"matchdetails_player_name").Set("innerText", "")
+	cm.document.Call("getElementById",
+		"matchdetails_opponent_name").Set("innerText", "")
+	cm.document.Call("getElementById",
+		"matchdetails_player_remainingtime").Set("innerText", "")
+	cm.document.Call("getElementById",
+		"matchdetails_opponent_remainingtime").Set("innerText", "")
+	cm.document.Call("getElementById",
+		"matchdetails_player_points").Set("innerText", "")
+	cm.document.Call("getElementById",
+		"matchdetails_opponent_points").Set("innerText", "")
+}
+
 func (cm *ClientModel) viewSetMatchDetailsPoints(
 	color model.Color, elementID string) {
 	points := cm.GetPointAdvantage(color)
@@ -93,6 +123,13 @@ func (cm *ClientModel) viewSetMatchDetailsPoints(
 
 func (cm *ClientModel) formatTime(ms int64) string {
 	return (time.Duration(ms) * time.Millisecond).String()
+}
+
+func (cm *ClientModel) viewSetGameOver(winner, winType string) {
+	addClass(cm.document.Call("getElementById", "gameover_modal"), "gameover_modal")
+	removeClass(cm.document.Call("getElementById", "gameover_modal"), "hidden")
+	cm.document.Call("getElementById", "gameover_modal_text").Set("innerText",
+		fmt.Sprintf("Winner: %s by %s", winner, winType))
 }
 
 func (clientModel *ClientModel) viewClearBoard() {

--- a/internal/server/http/webserver/webserver.go
+++ b/internal/server/http/webserver/webserver.go
@@ -130,7 +130,12 @@ func SyncHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		pieceMove := player.GetSyncUpdate()
-		json.NewEncoder(w).Encode(pieceMove)
+		if pieceMove != nil {
+			json.NewEncoder(w).Encode(*pieceMove)
+			return
+		}
+		// Return HTTP 204 if no update.
+		w.WriteHeader(http.StatusNoContent)
 	case "POST":
 		var moveRequest model.MoveRequest
 		err := json.NewDecoder(r.Body).Decode(&moveRequest)
@@ -156,6 +161,11 @@ func AsyncHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		asyncUpdate := player.GetAsyncUpdate()
+		if asyncUpdate == nil {
+			// Return HTTP 204 if no update.
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(asyncUpdate); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/server/http/webserver/webserver.go
+++ b/internal/server/http/webserver/webserver.go
@@ -99,6 +99,7 @@ func createSearchForMatchHandler(
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		log.SetPrefix("SearchForMatch: ")
 		player := getSession(w, r)
+		player.Reset()
 		if player == nil {
 			return
 		}

--- a/internal/server/match/matchserver.go
+++ b/internal/server/match/matchserver.go
@@ -67,6 +67,7 @@ func (player *Player) GetAsyncUpdate() ResponseAsync {
 }
 
 func (player *Player) Reset() {
+	player.elapsedMs = 0
 	player.requestChanSync = make(chan RequestSync, 1)
 	player.responseChanSync = make(chan ResponseSync, 10)
 	player.requestChanAsync = make(chan RequestAsync, 1)

--- a/internal/server/match/matchserver.go
+++ b/internal/server/match/matchserver.go
@@ -67,6 +67,11 @@ func (player *Player) GetAsyncUpdate() ResponseAsync {
 }
 
 func (player *Player) Reset() {
+	// If the player preexisted there may be a client waiting on the opponent's
+	// move.
+	if player.opponentPlayedMove != nil {
+		close(player.opponentPlayedMove)
+	}
 	player.elapsedMs = 0
 	player.requestChanSync = make(chan RequestSync, 1)
 	player.responseChanSync = make(chan ResponseSync, 10)

--- a/internal/server/match/matchserver.go
+++ b/internal/server/match/matchserver.go
@@ -19,15 +19,9 @@ type Player struct {
 }
 
 func NewPlayer(name string) Player {
-	return Player{
-		name: name, color: model.Black,
-		requestChanSync:    make(chan RequestSync, 1),
-		responseChanSync:   make(chan ResponseSync, 10),
-		requestChanAsync:   make(chan RequestAsync, 1),
-		responseChanAsync:  make(chan ResponseAsync, 1),
-		opponentPlayedMove: make(chan model.MoveRequest, 10),
-		matchStart:         make(chan struct{}),
-	}
+	player := Player{name: name, color: model.Black}
+	player.Reset()
+	return player
 }
 
 func (player *Player) Name() string {
@@ -72,12 +66,13 @@ func (player *Player) GetAsyncUpdate() ResponseAsync {
 	return <-player.responseChanAsync
 }
 
-func (player *Player) Stop() {
-	close(player.requestChanSync)
-	close(player.responseChanSync)
-	close(player.requestChanAsync)
-	close(player.responseChanAsync)
-	close(player.matchStart)
+func (player *Player) Reset() {
+	player.requestChanSync = make(chan RequestSync, 1)
+	player.responseChanSync = make(chan ResponseSync, 10)
+	player.requestChanAsync = make(chan RequestAsync, 1)
+	player.responseChanAsync = make(chan ResponseAsync, 1)
+	player.opponentPlayedMove = make(chan model.MoveRequest, 10)
+	player.matchStart = make(chan struct{})
 }
 
 type RequestSync struct {

--- a/internal/server/match/matchserver_test.go
+++ b/internal/server/match/matchserver_test.go
@@ -230,13 +230,13 @@ func TestMatchingServerCheckmate(t *testing.T) {
 	white.MakeMove(model.MoveRequest{model.Position{4, 1}, model.Move{0, 2}})
 	opponentMove := black.GetSyncUpdate()
 	expectedMove := model.MoveRequest{model.Position{4, 1}, model.Move{0, 2}}
-	if opponentMove != expectedMove {
+	if *opponentMove != expectedMove {
 		t.Error("Expected opponent's move got ", opponentMove)
 	}
 	black.MakeMove(model.MoveRequest{model.Position{0, 6}, model.Move{0, -1}})
 	opponentMove = white.GetSyncUpdate()
 	expectedMove = model.MoveRequest{model.Position{0, 6}, model.Move{0, -1}}
-	if opponentMove != expectedMove {
+	if *opponentMove != expectedMove {
 		t.Error("Expected opponent's move got ", opponentMove)
 	}
 	white.MakeMove(model.MoveRequest{model.Position{3, 0}, model.Move{4, 4}})


### PR DESCRIPTION
   - [x] Move from long polling to polling with tighter timeouts
   - [x] Show "pending draw" when requesting a draw
   - [x] Display gameover results
   - [x] Reset the matchserver.Player objects in the webserver so that the client can now play additional matches after their first