### PR TITLE
Detect draw by repetition

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ TODO
     - [x] timeout
     - [x] resignation
     - [x] agreed draw
-    - [ ] Detect draw by repetition (same position 3 times)
+    - [x] Detect draw by repetition (same position 3 times)
         See https://en.wikipedia.org/wiki/Threefold_repetition for the definition
         of position.
         Let's do this with a map[positionId]uint8

--- a/internal/model/game.go
+++ b/internal/model/game.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"sync"
 )
 
@@ -85,14 +84,12 @@ func (game *Game) updatePositionHistory() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	fmt.Printf("%x\n", position)
 	game.positionHistory[string(position)] += 1
 	return game.positionHistory[string(position)] > 2, nil
 }
 
 func (game *Game) MarshalBinary() (data []byte, err error) {
 	buf := new(bytes.Buffer)
-	println(game.turn)
 	err = binary.Write(buf, binary.BigEndian, game.turn)
 	if err != nil {
 		return nil, err

--- a/internal/model/game.go
+++ b/internal/model/game.go
@@ -1,20 +1,24 @@
 package model
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"sync"
 )
 
 type Game struct {
-	board         *board
-	turn          Color
-	gameOver      bool
-	result        GameResult
-	previousMove  Move
-	previousMover *Piece
-	blackKing     *Piece
-	whiteKing     *Piece
-	mutex         sync.RWMutex
+	board           *board
+	turn            Color
+	gameOver        bool
+	result          GameResult
+	previousMove    Move
+	previousMover   *Piece
+	blackKing       *Piece
+	whiteKing       *Piece
+	positionHistory map[string]uint8
+	mutex           sync.RWMutex
 }
 
 type GameResult struct {
@@ -54,6 +58,10 @@ func (game *Game) Move(moveRequest MoveRequest) error {
 	if err != nil {
 		return err
 	}
+	drawByRepetion, err := game.updatePositionHistory()
+	if err != nil {
+		return err
+	}
 	enemyColor := getOppositeColor(piece.color)
 	possibleEnemyMoves := AllMoves(
 		game.board, enemyColor, move, piece, false, enemyKing,
@@ -62,7 +70,7 @@ func (game *Game) Move(moveRequest MoveRequest) error {
 		enemyKing.isThreatened(game.board, move, piece) {
 		game.gameOver = true
 		game.result.Winner = game.turn
-	} else if len(possibleEnemyMoves) == 0 {
+	} else if len(possibleEnemyMoves) == 0 || drawByRepetion {
 		game.gameOver = true
 		game.result.Draw = true
 	}
@@ -70,6 +78,45 @@ func (game *Game) Move(moveRequest MoveRequest) error {
 	game.previousMover = piece
 	game.turn = enemyColor
 	return nil
+}
+
+func (game *Game) updatePositionHistory() (bool, error) {
+	position, err := game.MarshalBinary()
+	if err != nil {
+		return false, err
+	}
+	fmt.Printf("%x\n", position)
+	game.positionHistory[string(position)] += 1
+	return game.positionHistory[string(position)] > 2, nil
+}
+
+func (game *Game) MarshalBinary() (data []byte, err error) {
+	buf := new(bytes.Buffer)
+	println(game.turn)
+	err = binary.Write(buf, binary.BigEndian, game.turn)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range game.board {
+		for _, piece := range file {
+			if piece != nil {
+				king := game.blackKing
+				if piece.color == White {
+					king = game.whiteKing
+				}
+				bytes, err := piece.MarshalBinary(
+					game.board, game.previousMove, game.previousMover, king)
+				if err != nil {
+					return nil, err
+				}
+				err = binary.Write(buf, binary.BigEndian, bytes)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return buf.Bytes(), nil
 }
 
 func getOppositeColor(color Color) (opposite Color) {
@@ -83,18 +130,22 @@ func getOppositeColor(color Color) (opposite Color) {
 
 func NewGame() Game {
 	board := NewFullBoard()
-	return Game{
-		board: &board, turn: White,
-		blackKing: board[4][7], whiteKing: board[4][0],
-	}
+	return createGame(board)
 }
 
 func NewGameNoPawns() Game {
 	board := NewBoardNoPawns()
-	return Game{
-		board: &board, turn: White,
-		blackKing: board[4][7], whiteKing: board[4][0],
+	return createGame(board)
+}
+
+func createGame(board board) Game {
+	game := Game{
+		board: &board, blackKing: board[4][7], whiteKing: board[4][0],
+		positionHistory: make(map[string]uint8),
 	}
+	game.updatePositionHistory()
+	game.turn = White
+	return game
 }
 
 func (game *Game) Board() *board {

--- a/internal/model/move.go
+++ b/internal/model/move.go
@@ -318,20 +318,7 @@ func (piece *Piece) Moves(
 func (piece *Piece) canCastle(
 	board *board, previousMove Move, previousMover *Piece,
 ) (castleLeft, castleRight bool) {
-	if piece.pieceType != King || piece.movesTaken > 0 {
-		return false, false
-	}
-	rookPieces := [2]*Piece{board[0][piece.Rank()], board[7][piece.Rank()]}
-	castleLeft, castleRight = true, true
-	for i, rook := range rookPieces {
-		if rook == nil || rook.pieceType != Rook || rook.movesTaken != 0 {
-			if i == 0 {
-				castleLeft = false
-			} else {
-				castleRight = false
-			}
-		}
-	}
+	castleLeft, castleRight = piece.hasCastleRights(board)
 	if !castleLeft && !castleRight {
 		return false, false
 	}
@@ -347,6 +334,24 @@ func (piece *Piece) canCastle(
 		piece.wouldNotCastleThroughCheck(threatenedPositions)
 	castleLeft = castleLeft && noBlockLeft && noCheckLeft
 	castleRight = castleRight && noBlockRight && noCheckRight
+	return castleLeft, castleRight
+}
+
+func (piece *Piece) hasCastleRights(board *board) (castleLeft, castleRight bool) {
+	if piece.pieceType != King || piece.movesTaken > 0 {
+		return false, false
+	}
+	rookPieces := [2]*Piece{board[0][piece.Rank()], board[7][piece.Rank()]}
+	castleLeft, castleRight = true, true
+	for i, rook := range rookPieces {
+		if rook == nil || rook.pieceType != Rook || rook.movesTaken != 0 {
+			if i == 0 {
+				castleLeft = false
+			} else {
+				castleRight = false
+			}
+		}
+	}
 	return castleLeft, castleRight
 }
 


### PR DESCRIPTION
* Methods for binary encoding the game's _position_, defined [here](https://en.wikipedia.org/wiki/Threefold_repetition#:~:text=In%20chess%2C%20the%20threefold%20repetition,as%20triple%20occurrence%20of%20position.).  To meet this definition we include the turn, piece types, positions, locations, and number of temporary movement rights.
* Store the number of times the game has been in a given position, if this reaches 3 the game ends in a draw.