### PR TITLE
50 move rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ TODO
         - [x] Display point advantage/captured pieces
         - [x] Play local match vs begin matchmaking
         - [x] Mobile support
-        - [] Support pieceType options for pawn promotion
+        - [ ] Support pieceType options for pawn promotion
 * General
     - [x] Travis CI test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TODO
     - [x] Detect stalemate
     - [x] Handle pawn promotion
     - [ ] Insufficient material
-    - [ ] 50 move rule
+    - [x] 50 move rule
     - [x] timeout
     - [x] resignation
     - [x] agreed draw

--- a/internal/model/game.go
+++ b/internal/model/game.go
@@ -162,6 +162,12 @@ func createGame(board board) Game {
 	return game
 }
 
+func (game *Game) BoardString() string {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.board.String()
+}
+
 func (game *Game) Board() *board {
 	game.mutex.RLock()
 	defer game.mutex.RUnlock()

--- a/internal/model/game.go
+++ b/internal/model/game.go
@@ -37,7 +37,7 @@ func (game *Game) Move(moveRequest MoveRequest) error {
 	defer game.mutex.Unlock()
 	move := moveRequest.Move
 	piece := game.board[moveRequest.Position.File][moveRequest.Position.Rank]
-	err := game.isValidTimeToMove(piece)
+	err := game.isMoveRequestValid(piece)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (game *Game) Move(moveRequest MoveRequest) error {
 	return nil
 }
 
-func (game *Game) isValidTimeToMove(piece *Piece) error {
+func (game *Game) isMoveRequestValid(piece *Piece) error {
 	if game.gameOver {
 		return errors.New("The game is over")
 	} else if piece == nil {

--- a/internal/model/game.go
+++ b/internal/model/game.go
@@ -8,16 +8,17 @@ import (
 )
 
 type Game struct {
-	board           *board
-	turn            Color
-	gameOver        bool
-	result          GameResult
-	previousMove    Move
-	previousMover   *Piece
-	blackKing       *Piece
-	whiteKing       *Piece
-	positionHistory map[string]uint8
-	mutex           sync.RWMutex
+	board                       *board
+	turn                        Color
+	gameOver                    bool
+	result                      GameResult
+	previousMove                Move
+	previousMover               *Piece
+	blackKing                   *Piece
+	whiteKing                   *Piece
+	positionHistory             map[string]uint8
+	turnsSinceCaptureOrPawnMove uint8
+	mutex                       sync.RWMutex
 }
 
 type GameResult struct {
@@ -31,28 +32,17 @@ type MoveRequest struct {
 	PromoteTo *PieceType
 }
 
-var ErrGameOver = errors.New("The game is over")
-
 func (game *Game) Move(moveRequest MoveRequest) error {
 	game.mutex.Lock()
 	defer game.mutex.Unlock()
-	position := moveRequest.Position
 	move := moveRequest.Move
-	piece := game.board[position.File][position.Rank]
-	if game.gameOver {
-		return ErrGameOver
-	} else if piece == nil {
-		return errors.New("Cannot move nil piece")
-	} else if piece.color != game.turn {
-		return errors.New("It's not your turn")
+	piece := game.board[moveRequest.Position.File][moveRequest.Position.Rank]
+	err := game.isValidTimeToMove(piece)
+	if err != nil {
+		return err
 	}
-	king := game.blackKing
-	enemyKing := game.whiteKing
-	if game.turn == White {
-		king = game.whiteKing
-		enemyKing = game.blackKing
-	}
-	err := piece.takeMove(game.board, move, game.previousMove,
+	king, enemyKing := game.getKings()
+	isCapture, err := piece.takeMove(game.board, move, game.previousMove,
 		game.previousMover, king, moveRequest.PromoteTo)
 	if err != nil {
 		return err
@@ -61,6 +51,12 @@ func (game *Game) Move(moveRequest MoveRequest) error {
 	if err != nil {
 		return err
 	}
+	if piece.pieceType != Pawn && !isCapture {
+		game.turnsSinceCaptureOrPawnMove++
+	} else {
+		game.turnsSinceCaptureOrPawnMove = 0
+	}
+	fiftyMoveRule := game.turnsSinceCaptureOrPawnMove >= 100
 	enemyColor := getOppositeColor(piece.color)
 	possibleEnemyMoves := AllMoves(
 		game.board, enemyColor, move, piece, false, enemyKing,
@@ -69,7 +65,7 @@ func (game *Game) Move(moveRequest MoveRequest) error {
 		enemyKing.isThreatened(game.board, move, piece) {
 		game.gameOver = true
 		game.result.Winner = game.turn
-	} else if len(possibleEnemyMoves) == 0 || drawByRepetion {
+	} else if len(possibleEnemyMoves) == 0 || drawByRepetion || fiftyMoveRule {
 		game.gameOver = true
 		game.result.Draw = true
 	}
@@ -77,6 +73,27 @@ func (game *Game) Move(moveRequest MoveRequest) error {
 	game.previousMover = piece
 	game.turn = enemyColor
 	return nil
+}
+
+func (game *Game) isValidTimeToMove(piece *Piece) error {
+	if game.gameOver {
+		return errors.New("The game is over")
+	} else if piece == nil {
+		return errors.New("Cannot move nil piece")
+	} else if piece.color != game.turn {
+		return errors.New("It's not your turn")
+	}
+	return nil
+}
+
+func (game *Game) getKings() (king, enemyKing *Piece) {
+	king = game.blackKing
+	enemyKing = game.whiteKing
+	if game.turn == White {
+		king = game.whiteKing
+		enemyKing = game.blackKing
+	}
+	return
 }
 
 func (game *Game) updatePositionHistory() (bool, error) {

--- a/internal/model/game_test.go
+++ b/internal/model/game_test.go
@@ -242,12 +242,96 @@ func TestDrawByRepetion(t *testing.T) {
 	if debug {
 		fmt.Println(game.board)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 2; i++ {
 		game.Move(MoveRequest{Position{3, 0}, Move{1, 1}, nil})
 		game.Move(MoveRequest{Position{3, 7}, Move{0, -1}, nil})
 		game.Move(MoveRequest{Position{4, 1}, Move{-1, -1}, nil})
-		game.Move(MoveRequest{Position{3, 6}, Move{0, 1}, nil})
+		err := game.Move(MoveRequest{Position{3, 6}, Move{0, 1}, nil})
+		if err != nil {
+			t.Error("Draw too early")
+		}
 	}
+	if !game.gameOver || !game.result.Draw {
+		t.Error("Game should be a draw")
+	}
+}
+
+func TestDrawByFiftyMoveRule(t *testing.T) {
+	game := NewGameNoPawns()
+	if game.gameOver != false || game.result.Draw == true {
+		t.Error("Game should not be over")
+	}
+	if debug {
+		fmt.Println(game.board)
+	}
+	game.Move(MoveRequest{Position{2, 0}, Move{-2, 2}, nil})
+	game.Move(MoveRequest{Position{5, 7}, Move{-5, -5}, nil})
+	// 1 move without capture
+	game.Move(MoveRequest{Position{3, 0}, Move{0, 1}, nil})
+	game.Move(MoveRequest{Position{0, 2}, Move{5, 5}, nil})
+	// 24 moves without capture
+	for i := uint8(0); i < 6; i++ {
+		// Move knight out and back
+		game.Move(MoveRequest{Position{1, 0}, Move{1, 2}, nil})
+		game.Move(MoveRequest{Position{1, 7}, Move{1, -2}, nil})
+		game.Move(MoveRequest{Position{2, 2}, Move{-1, -2}, nil})
+		game.Move(MoveRequest{Position{2, 5}, Move{-1, 2}, nil})
+		// Move bishop out and back
+		if i%2 == 0 {
+			game.Move(MoveRequest{Position{5, 0}, Move{-1, 1}, nil})
+			game.Move(MoveRequest{Position{5, 7}, Move{-1, -1}, nil})
+		} else {
+			game.Move(MoveRequest{Position{4, 1}, Move{1, -1}, nil})
+			game.Move(MoveRequest{Position{4, 6}, Move{1, 1}, nil})
+		}
+		// Move rook
+		game.Move(MoveRequest{Position{0, i}, Move{0, 1}, nil})
+		err := game.Move(MoveRequest{Position{7, 7 - i}, Move{0, -1}, nil})
+		if err != nil {
+			t.Error("Draw too early")
+		}
+	}
+	// 1 move without capture
+	game.Move(MoveRequest{Position{0, 6}, Move{1, 0}, nil})
+	game.Move(MoveRequest{Position{7, 1}, Move{-1, 0}, nil})
+	// 5 moves without capture
+	for i := uint8(0); i < 5; i++ {
+		game.Move(MoveRequest{Position{1, 6 - i}, Move{0, -1}, nil})
+		err := game.Move(MoveRequest{Position{6, i + 1}, Move{0, 1}, nil})
+		if err != nil {
+			t.Error("Draw too early")
+		}
+	}
+	// 1 move without capture
+	game.Move(MoveRequest{Position{1, 1}, Move{1, 0}, nil})
+	game.Move(MoveRequest{Position{6, 6}, Move{-1, 0}, nil})
+	// 16 moves without capture
+	for i := uint8(0); i < 4; i++ {
+		// Move knight out and back
+		game.Move(MoveRequest{Position{1, 0}, Move{-1, 2}, nil})
+		game.Move(MoveRequest{Position{1, 7}, Move{-1, -2}, nil})
+		game.Move(MoveRequest{Position{0, 2}, Move{1, -2}, nil})
+		game.Move(MoveRequest{Position{0, 5}, Move{1, 2}, nil})
+		// Move bishop out and back
+		if i%2 == 0 {
+			game.Move(MoveRequest{Position{5, 0}, Move{-1, 1}, nil})
+			game.Move(MoveRequest{Position{5, 7}, Move{-1, -1}, nil})
+		} else {
+			game.Move(MoveRequest{Position{4, 1}, Move{1, -1}, nil})
+			game.Move(MoveRequest{Position{4, 6}, Move{1, 1}, nil})
+		}
+		// Move rook
+		game.Move(MoveRequest{Position{2, i + 1}, Move{0, 1}, nil})
+		err := game.Move(MoveRequest{Position{5, 6 - i}, Move{0, -1}, nil})
+		if err != nil {
+			t.Error("Draw too early")
+		}
+	}
+	// 2 moves without capture
+	game.Move(MoveRequest{Position{1, 0}, Move{-1, 2}, nil})
+	game.Move(MoveRequest{Position{1, 7}, Move{-1, -2}, nil})
+	game.Move(MoveRequest{Position{0, 2}, Move{1, -2}, nil})
+	game.Move(MoveRequest{Position{0, 5}, Move{1, 2}, nil})
 	if !game.gameOver || !game.result.Draw {
 		t.Error("Game should be a draw")
 	}

--- a/internal/model/game_test.go
+++ b/internal/model/game_test.go
@@ -33,6 +33,30 @@ func TestMoves(t *testing.T) {
 	}
 }
 
+func TestLotsOfPawns(t *testing.T) {
+	game := NewGame()
+	if debug {
+		fmt.Println(game.board)
+	}
+	game.Move(MoveRequest{Position{0, 1}, Move{0, 2}, nil})
+	game.Move(MoveRequest{Position{0, 6}, Move{0, -2}, nil})
+	game.Move(MoveRequest{Position{1, 1}, Move{0, 2}, nil})
+	game.Move(MoveRequest{Position{1, 6}, Move{0, -2}, nil})
+	game.Move(MoveRequest{Position{2, 1}, Move{0, 2}, nil})
+	game.Move(MoveRequest{Position{2, 6}, Move{0, -2}, nil})
+	game.Move(MoveRequest{Position{3, 1}, Move{0, 2}, nil})
+	game.Move(MoveRequest{Position{3, 6}, Move{0, -2}, nil})
+	game.Move(MoveRequest{Position{4, 1}, Move{0, 2}, nil})
+	game.Move(MoveRequest{Position{4, 6}, Move{0, -2}, nil})
+	game.Move(MoveRequest{Position{5, 1}, Move{0, 2}, nil})
+	game.Move(MoveRequest{Position{5, 6}, Move{0, -2}, nil})
+	for i := 0; i < 6; i++ {
+		if game.board[i][3] == nil || game.board[i][4] == nil {
+			t.Error("Pawns did not move as expected")
+		}
+	}
+}
+
 func TestPoints(t *testing.T) {
 	game := NewGame()
 	if debug {

--- a/internal/model/move.go
+++ b/internal/model/move.go
@@ -77,7 +77,9 @@ func (piece *Piece) takeMoveUnsafe(
 	isEnPassant := (piece.pieceType == Pawn && newX != piece.File() &&
 		enPassantTarget != nil && enPassantTarget == previousMover &&
 		enPassantTarget.pieceType == Pawn &&
-		(previousMove.Y == 2 || previousMove.Y == -2))
+		(previousMove.Y == 2 || previousMove.Y == -2) &&
+		piece.Rank() == enPassantTargetY &&
+		piece.Color() != enPassantTarget.Color())
 	isCastle := piece.pieceType == King && (move.X < -1 || move.X > 1)
 	if isEnPassant {
 		capturedPiece = board[enPassantTarget.File()][enPassantTarget.Rank()]

--- a/internal/server/http/webclient/webclient.go
+++ b/internal/server/http/webclient/webclient.go
@@ -24,6 +24,7 @@ type ClientModel struct {
 	elDragging               js.Value
 	pieceDragging            *model.Piece
 	draggingOrigTransform    js.Value
+	isMouseDownLock          sync.Mutex
 	isMouseDown              bool
 	positionOriginal         model.Position
 	isMatchmaking, isMatched bool
@@ -59,6 +60,12 @@ func (cm *ClientModel) GetGameType() GameType {
 	cm.cmMutex.RLock()
 	defer cm.cmMutex.RUnlock()
 	return cm.gameType
+}
+
+func (cm *ClientModel) GetBoard() string {
+	cm.cmMutex.RLock()
+	defer cm.cmMutex.RUnlock()
+	return cm.game.BoardString()
 }
 
 func (cm *ClientModel) SetGameType(gameType GameType) {
@@ -155,16 +162,24 @@ func (cm *ClientModel) SetDraggingOriginalTransform(el js.Value) {
 	cm.draggingOrigTransform = el
 }
 
+func (cm *ClientModel) LockMouseDown() {
+	cm.cmMutex.Lock()
+	defer cm.cmMutex.Unlock()
+	cm.isMouseDownLock.Lock()
+	cm.isMouseDown = true
+}
+
+func (cm *ClientModel) UnlockMouseDown() {
+	cm.cmMutex.Lock()
+	defer cm.cmMutex.Unlock()
+	defer cm.isMouseDownLock.Unlock()
+	cm.isMouseDown = false
+}
+
 func (cm *ClientModel) GetIsMouseDown() bool {
 	cm.cmMutex.RLock()
 	defer cm.cmMutex.RUnlock()
 	return cm.isMouseDown
-}
-
-func (cm *ClientModel) SetIsMouseDown(isMouseDown bool) {
-	cm.cmMutex.Lock()
-	defer cm.cmMutex.Unlock()
-	cm.isMouseDown = isMouseDown
 }
 
 func (cm *ClientModel) GetClickOriginalPosition() model.Position {

--- a/internal/server/http/webclient/webclient.go
+++ b/internal/server/http/webclient/webclient.go
@@ -62,7 +62,7 @@ func (cm *ClientModel) GetGameType() GameType {
 	return cm.gameType
 }
 
-func (cm *ClientModel) GetBoard() string {
+func (cm *ClientModel) GetBoardString() string {
 	cm.cmMutex.RLock()
 	defer cm.cmMutex.RUnlock()
 	return cm.game.BoardString()

--- a/internal/server/http/webclient/webclientcontroller.go
+++ b/internal/server/http/webclient/webclientcontroller.go
@@ -110,7 +110,7 @@ func (clientModel *ClientModel) handleClickStart(
 		if debug {
 			log.Println("ERROR: Clicked a piece that is not on the board")
 			log.Println(clientModel.positionOriginal)
-			log.Println(clientModel.GetBoard())
+			log.Println(clientModel.GetBoardString())
 		}
 		clientModel.UnlockMouseDown()
 		return


### PR DESCRIPTION
* 50 move rule draw detection
* Fix bug where a valid move initiated in between two pieces would leave the UI and game state out of sync
* Fix bug with takeMoveUnsafe where a friendly pawn could be seen as a valid en passant target and cause issues during revert (and added test TestLotsOfPawns which catches this issue)
* Some minor cleanup