### PR TITLE
Handle client reconnect to a game in progress

### DIFF
--- a/APISPEC.md
+++ b/APISPEC.md
@@ -1,5 +1,8 @@
 - POST /session
     - Start the session and fetch sessionToken, providing username
+- GET /session
+    - Get a session and username if one exists and match details if currently in one
+    - Client calls this on page load and sets username/game state accordingly
 - GET /match
     - Begin matching, receive color when match is found, otherwise HTTP 202
 - POST /sync
@@ -11,6 +14,3 @@
         - gameOver, requestToDraw, gameOver results
 - GET /sync
     - Get opponents move (should query this after a successful move), returns HTTP 204 if no update after server timeout
-- GET /session
-    - Get a session if one exists, match details if currently in one
-    - Client calls this on page load and sets username/game state accordingly

--- a/APISPEC.md
+++ b/APISPEC.md
@@ -11,6 +11,6 @@
         - gameOver, requestToDraw, gameOver results
 - GET /sync
     - Get opponents move (should query this after a successful move), returns HTTP 204 if no update after server timeout
-- GET /currentmatch
-    - Get the state of the board (call this to check if in a game and to get the state of it if so)
-    - Return 404 if not in a game, 200 with state otherwise
+- GET /session
+    - Get a session if one exists, match details if currently in one
+    - Client calls this on page load and sets username/game state accordingly

--- a/APISPEC.md
+++ b/APISPEC.md
@@ -11,6 +11,6 @@
         - gameOver, requestToDraw, gameOver results
 - GET /sync
     - Get opponents move (should query this after a successful move), returns HTTP 204 if no update after server timeout
-- GET /currentgame
+- GET /currentmatch
     - Get the state of the board (call this to check if in a game and to get the state of it if so)
     - Return 404 if not in a game, 200 with state otherwise

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,11 @@
     - http server
       - [ ] If no response from client in x seconds then call disconnect win for opponent
       - [ ] Support some mechanism for a user cancelling their matchmaking
-      - [ ] Implement /currentgame so that a disconnected client can reconnect
+      - [ ] Implement /currentmatch so that a disconnected client can reconnect
+        - On initial page load call /currentgame if the session_token is set
+        - Server will return the corresponding username (credentials) regardless of if a game is ongoing or not, client will set the username input to that username
+        - Server will also check for an ongoing game, if one is ongoing send the game state to the client, client will set the game state accordingly
+        - Upgrade WS handler to check for an ongoing game when the client connects
       - [ ] Use browser session storage to save the session token cookie, that way a client can refresh and check if their token is still valid/in a game https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
     - http server sessions
       - [ ] user auth?

--- a/TODO.md
+++ b/TODO.md
@@ -1,24 +1,14 @@
 ### Todo
 * Observability
-    - [ ] Prometheus metrics
-        - [ ] more?
+    - [ ] More Prometheus metrics
     - [ ] Improve logging
 * Server
     - http server
-      - [ ] If no response from client in x seconds then call disconnect win for opponent
       - [ ] Support some mechanism for a user cancelling their matchmaking
-      - [ ] Implement GET /session so that a disconnected client can reconnect
-        - On initial page load call /session
-        - Server will return the corresponding username (credentials) regardless of if a game is ongoing or not, client will set the username input to that username
-        - Server will also check for an ongoing game, if one is ongoing send the game state to the client, client will set the game state accordingly
-        - [] handle disconnected client gracefully, let matchserver know on disconnect and it starts a timer, ending game with timeout on alarm
-        - [x] redesign clientDoneWithMatch, instead the match signifies when it's over and client servers synchronize on that, resetting themselves.  The other way around required client servers to let the matchserver know when they were done with a match, this made less sense because a client could have disconnected and take some time to reconnect and it's harder to tell when they're done.  Worth noting here that to scale we would likely want to be somewhat aggressive on reeping inactive players in sessionCache, because players could frequently disconnect when losing without formally resigning and letting their client server reset the player object, thus keeping a reference to the match and preventing GC.
-      - [ ] Use browser session storage to save the session token cookie, that way a client can refresh and check if their token is still valid/in a game https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
+        - Probably would require a matching redesign, right now matchmaking is handled from a channel which doesn't support adhoc removal
+    - [] handle disconnected WS client gracefully, let matchserver know on disconnect and it starts a timer, ending game with timeout on alarm
     - http server sessions
       - [ ] user auth?
-* Client
-    - [ ] Check cookies for session token instead of using hasSession bool
-        - Not sure if possible, the golang cookiejar doesn't seem like it supports this.
 
 ### Done
 * Observability
@@ -60,6 +50,13 @@
       - [x] resignation test
       - [x] timeout test
       - [x] GET /sync should also provide player and opponent's remaining time to keep client, server in sync (implemented for WS only)
+      - [x] Implement GET /session so that a disconnected client can reconnect
+        - On initial page load client calls /session
+        - Server will return the user's username if supplied a valid token
+        - Server will also check for an ongoing game, if one is ongoing it sends the game state to the client, client will set the game state accordingly and rejoin the game
+        - [x] Redesign websocket to gracefully handle an initial connection + match request and a reconnect
+        - [x] Implement reconnect logic in web client
+        - [x] Redesign clientDoneWithMatch, instead the match signifies when it's over and client servers synchronize on that (WaitForMatchOver), then resetting themselves.  The other way around required client servers to let the matchserver know when they were done with a match, this made less sense because a client could have disconnected and take some time to reconnect, it's harder to tell when they're done with the match.  Worth noting here that to scale we would likely want to be somewhat aggressive on reeping inactive players in sessionCache, because players could frequently disconnect when losing without formally resigning and letting their client server reset the player object, thus keeping a reference to the match and preventing GC.
     - [x] http server sessions
       - [x] testing
     - [x] client agnostic matching server

--- a/TODO.md
+++ b/TODO.md
@@ -7,11 +7,13 @@
     - http server
       - [ ] If no response from client in x seconds then call disconnect win for opponent
       - [ ] Support some mechanism for a user cancelling their matchmaking
-      - [ ] Implement /currentmatch so that a disconnected client can reconnect
-        - On initial page load call /currentgame if the session_token is set
+      - [ ] Implement GET /session so that a disconnected client can reconnect
+        - On initial page load call /session
         - Server will return the corresponding username (credentials) regardless of if a game is ongoing or not, client will set the username input to that username
         - Server will also check for an ongoing game, if one is ongoing send the game state to the client, client will set the game state accordingly
-        - Upgrade WS handler to check for an ongoing game when the client connects
+        - [] clientDoneWithMatch needs to either not be closed immediately on websocket loop exit, or we need to re-init it on reconnect, or redeign e.g.:
+          - matchserver does not handle player.Reset, leaves it to client servers, and instead of client server instances telling matchserver when they're done with the match, the matchserver signifies in the match object when it's over over and client servers wait for that and then reset players
+        - [] debug why pieces aren't looking right for the client
       - [ ] Use browser session storage to save the session token cookie, that way a client can refresh and check if their token is still valid/in a game https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
     - http server sessions
       - [ ] user auth?

--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,7 @@
         - Server will return the user's username if supplied a valid token
         - Server will also check for an ongoing game, if one is ongoing it sends the game state to the client, client will set the game state accordingly and rejoin the game
         - [x] Redesign websocket to gracefully handle an initial connection + match request and a reconnect
+        - [x] test websocket reconnect, and add a lock for each session.  We should only process one request from a session at a time (WS or http)
         - [x] Implement reconnect logic in web client
         - [x] Redesign clientDoneWithMatch, instead the match signifies when it's over and client servers synchronize on that (WaitForMatchOver), then resetting themselves.  The other way around required client servers to let the matchserver know when they were done with a match, this made less sense because a client could have disconnected and take some time to reconnect, it's harder to tell when they're done with the match.  Worth noting here that to scale we would likely want to be somewhat aggressive on reeping inactive players in sessionCache, because players could frequently disconnect when losing without formally resigning and letting their client server reset the player object, thus keeping a reference to the match and preventing GC.
     - [x] http server sessions

--- a/TODO.md
+++ b/TODO.md
@@ -11,9 +11,8 @@
         - On initial page load call /session
         - Server will return the corresponding username (credentials) regardless of if a game is ongoing or not, client will set the username input to that username
         - Server will also check for an ongoing game, if one is ongoing send the game state to the client, client will set the game state accordingly
-        - [] clientDoneWithMatch needs to either not be closed immediately on websocket loop exit, or we need to re-init it on reconnect, or redeign e.g.:
-          - matchserver does not handle player.Reset, leaves it to client servers, and instead of client server instances telling matchserver when they're done with the match, the matchserver signifies in the match object when it's over over and client servers wait for that and then reset players
         - [] debug why pieces aren't looking right for the client
+        - [x] redesign clientDoneWithMatch, instead the match signifies when it's over and client servers synchronize on that, resetting themselves.  The other way around required client servers to let the matchserver know when they were done with a match, this made less sense because a client could have disconnected and take some time to reconnect and it's harder to tell when they're done.  Worth noting here that to scale we would likely want to be somewhat aggressive on reeping inactive players in sessionCache, because players could frequently disconnect when losing without formally resigning and letting their client server reset the player object, thus keeping a reference to the match and preventing GC.
       - [ ] Use browser session storage to save the session token cookie, that way a client can refresh and check if their token is still valid/in a game https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
     - http server sessions
       - [ ] user auth?

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
         - On initial page load call /session
         - Server will return the corresponding username (credentials) regardless of if a game is ongoing or not, client will set the username input to that username
         - Server will also check for an ongoing game, if one is ongoing send the game state to the client, client will set the game state accordingly
-        - [] debug why pieces aren't looking right for the client
+        - [] handle disconnected client gracefully, let matchserver know on disconnect and it starts a timer, ending game with timeout on alarm
         - [x] redesign clientDoneWithMatch, instead the match signifies when it's over and client servers synchronize on that, resetting themselves.  The other way around required client servers to let the matchserver know when they were done with a match, this made less sense because a client could have disconnected and take some time to reconnect and it's harder to tell when they're done.  Worth noting here that to scale we would likely want to be somewhat aggressive on reeping inactive players in sessionCache, because players could frequently disconnect when losing without formally resigning and letting their client server reset the player object, thus keeping a reference to the match and preventing GC.
       - [ ] Use browser session storage to save the session token cookie, that way a client can refresh and check if their token is still valid/in a game https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
     - http server sessions

--- a/internal/client/web/main.go
+++ b/internal/client/web/main.go
@@ -47,6 +47,7 @@ func main() {
 	clientModel.initController()
 	clientModel.initStyle()
 	clientModel.viewInitBoard(clientModel.playerColor)
+	clientModel.checkForSession()
 	<-done
 }
 

--- a/internal/client/web/webclient.go
+++ b/internal/client/web/webclient.go
@@ -40,6 +40,7 @@ type (
 		gameMutex                sync.RWMutex
 		game                     *model.Game
 		remoteMatchModel         RemoteMatchModel
+		buttonLoader             js.Value
 		// Unchanging elements
 		document          js.Value
 		board             js.Value
@@ -105,8 +106,9 @@ func (cm *ClientModel) RejoinMatch(match gateway.CurrentMatch) {
 	}
 	cm.SetPlayerColor(myColor)
 	cm.SetOpponentName(opponentName)
-	cm.SetPlayerElapsedMs(model.Black, match.BlackRemainingTimeMs)
-	cm.SetPlayerElapsedMs(model.White, match.WhiteRemainingTimeMs)
+	cm.SetMaxTimeMs(match.MaxTimeMs)
+	cm.SetPlayerElapsedMs(model.Black, match.MaxTimeMs-match.BlackRemainingTimeMs)
+	cm.SetPlayerElapsedMs(model.White, match.MaxTimeMs-match.WhiteRemainingTimeMs)
 	cm.handleRejoinMatch(match)
 }
 
@@ -380,4 +382,16 @@ func (cm *ClientModel) SetWSConn(conn js.Value) {
 	cm.cmMutex.Lock()
 	defer cm.cmMutex.Unlock()
 	cm.wsConn = conn
+}
+
+func (cm *ClientModel) GetButtonLoader() js.Value {
+	cm.cmMutex.RLock()
+	defer cm.cmMutex.RUnlock()
+	return cm.buttonLoader
+}
+
+func (cm *ClientModel) SetButtonLoader(buttonLoader js.Value) {
+	cm.cmMutex.Lock()
+	defer cm.cmMutex.Unlock()
+	cm.buttonLoader = buttonLoader
 }

--- a/internal/client/web/webclient.go
+++ b/internal/client/web/webclient.go
@@ -8,7 +8,6 @@ import (
 	"syscall/js"
 
 	"github.com/Ekotlikoff/gochess/internal/model"
-	gateway "github.com/Ekotlikoff/gochess/internal/server/frontend"
 )
 
 const (
@@ -95,21 +94,6 @@ func (cm *ClientModel) GetTurn() model.Color {
 	cm.gameMutex.Lock()
 	defer cm.gameMutex.Unlock()
 	return cm.game.Turn()
-}
-
-func (cm *ClientModel) RejoinMatch(match gateway.CurrentMatch) {
-	myColor := model.Black
-	opponentName := match.WhiteName
-	if opponentName == cm.GetPlayerName() {
-		myColor = model.White
-		opponentName = match.BlackName
-	}
-	cm.SetPlayerColor(myColor)
-	cm.SetOpponentName(opponentName)
-	cm.SetMaxTimeMs(match.MaxTimeMs)
-	cm.SetPlayerElapsedMs(model.Black, match.MaxTimeMs-match.BlackRemainingTimeMs)
-	cm.SetPlayerElapsedMs(model.White, match.MaxTimeMs-match.WhiteRemainingTimeMs)
-	cm.handleRejoinMatch(match)
 }
 
 func (cm *ClientModel) GetPointAdvantage(color model.Color) int8 {

--- a/internal/client/web/webclient.go
+++ b/internal/client/web/webclient.go
@@ -8,6 +8,7 @@ import (
 	"syscall/js"
 
 	"github.com/Ekotlikoff/gochess/internal/model"
+	gateway "github.com/Ekotlikoff/gochess/internal/server/frontend"
 )
 
 const (
@@ -93,6 +94,20 @@ func (cm *ClientModel) GetTurn() model.Color {
 	cm.gameMutex.Lock()
 	defer cm.gameMutex.Unlock()
 	return cm.game.Turn()
+}
+
+func (cm *ClientModel) RejoinMatch(match gateway.CurrentMatch) {
+	myColor := model.Black
+	opponentName := match.WhiteName
+	if opponentName == cm.GetPlayerName() {
+		myColor = model.White
+		opponentName = match.BlackName
+	}
+	cm.SetPlayerColor(myColor)
+	cm.SetOpponentName(opponentName)
+	cm.SetPlayerElapsedMs(model.Black, match.BlackRemainingTimeMs)
+	cm.SetPlayerElapsedMs(model.White, match.WhiteRemainingTimeMs)
+	cm.handleRejoinMatch(match)
 }
 
 func (cm *ClientModel) GetPointAdvantage(color model.Color) int8 {

--- a/internal/client/web/webclientcontroller.go
+++ b/internal/client/web/webclientcontroller.go
@@ -43,7 +43,7 @@ func (cm *ClientModel) initController() {
 }
 
 func (cm *ClientModel) checkForSession() {
-	resp, err := cm.client.Get("session", ctp, credentialsBuf)
+	resp, err := cm.client.Get("session", ctp)
 	if err == nil {
 		resp.Body.Close()
 	}

--- a/internal/client/web/webclientcontroller.go
+++ b/internal/client/web/webclientcontroller.go
@@ -582,7 +582,10 @@ func (cm *ClientModel) httpMatch() error {
 }
 
 func (cm *ClientModel) wsMatch() error {
-	err := cm.wsConnect()
+	var err error
+	if cm.GetWSConn().Equal(js.Undefined()) {
+		err = cm.wsConnect()
+	}
 	if err == nil {
 		message := matchserver.WebsocketRequest{
 			WebsocketRequestType: matchserver.RequestAsyncT,

--- a/internal/client/web/webclientcontroller.go
+++ b/internal/client/web/webclientcontroller.go
@@ -43,7 +43,7 @@ func (cm *ClientModel) initController() {
 }
 
 func (cm *ClientModel) checkForSession() {
-	resp, err := cm.client.Get("session", ctp)
+	resp, err := cm.client.Get("session")
 	if err == nil {
 		resp.Body.Close()
 	}

--- a/internal/client/web/webclientcontroller.go
+++ b/internal/client/web/webclientcontroller.go
@@ -470,6 +470,12 @@ func (cm *ClientModel) lookForMatch() {
 		if err == nil {
 			resp.Body.Close()
 		}
+		if err != nil || resp.StatusCode != 200 {
+			log.Println("Error starting session")
+			buttonLoader.Call("remove")
+			cm.SetIsMatchmaking(false)
+			return
+		}
 		cm.SetPlayerName(username)
 		cm.SetHasSession(true)
 	}

--- a/internal/client/web/webclientcontroller.go
+++ b/internal/client/web/webclientcontroller.go
@@ -42,6 +42,17 @@ func (cm *ClientModel) initController() {
 		cm.genCloseModalOnClick())
 }
 
+func (cm *ClientModel) checkForSession() {
+	resp, err := cm.client.Get("session", ctp, credentialsBuf)
+	if err == nil {
+		resp.Body.Close()
+	}
+	if err != nil || resp.StatusCode != 200 {
+		log.Println("Error starting session")
+		return
+	}
+}
+
 func (cm *ClientModel) genMouseDown() js.Func {
 	return js.FuncOf(func(this js.Value, i []js.Value) interface{} {
 		if len(i) > 0 && !cm.GetIsMouseDown() {

--- a/internal/client/web/webclientview.go
+++ b/internal/client/web/webclientview.go
@@ -150,7 +150,7 @@ func (clientModel *ClientModel) viewInitBoard(playerColor model.Color) {
 				div.Get("classList").Call("add", "piece")
 				div.Get("classList").Call("add", piece.ClientString())
 				div.Get("classList").Call(
-					"add", getPositionClass(piece.Position(), playerColor))
+					"add", getPositionClass(piece.Position, playerColor))
 				clientModel.board.Call("appendChild", div)
 				div.Call("addEventListener", "mousedown",
 					clientModel.genMouseDown(), false)
@@ -250,7 +250,7 @@ func (cm *ClientModel) genPromoteOnClick() js.Func {
 func (cm *ClientModel) viewHandleEnPassant(
 	move model.Move, newPos model.Position, targetEmpty bool) {
 	pawn := cm.game.GetBoard().Piece(newPos)
-	if pawn.PieceType() == model.Pawn && move.X != 0 && targetEmpty {
+	if pawn.PieceType == model.Pawn && move.X != 0 && targetEmpty {
 		capturedY := pawn.Rank() + 1
 		if move.Y > 0 {
 			capturedY = pawn.Rank() - 1
@@ -268,7 +268,7 @@ func (cm *ClientModel) viewHandleEnPassant(
 func (cm *ClientModel) viewHandleCastle(
 	move model.Move, newPos model.Position) {
 	king := cm.game.GetBoard().Piece(newPos)
-	if king.PieceType() == model.King &&
+	if king.PieceType == model.King &&
 		(move.X < -1 || move.X > 1) {
 		var rookPosition model.Position
 		var rookPosClass string

--- a/internal/client/web/webclientview.go
+++ b/internal/client/web/webclientview.go
@@ -295,11 +295,11 @@ func (cm *ClientModel) viewHandleCastle(
 	}
 }
 
-func (clientModel *ClientModel) buttonBeginLoading(button js.Value) js.Value {
-	i := clientModel.document.Call("createElement", "div")
-	i.Get("classList").Call("add", "loading")
-	button.Call("appendChild", i)
-	return i
+func (clientModel *ClientModel) buttonBeginLoading(button js.Value) {
+	buttonLoader := clientModel.document.Call("createElement", "div")
+	clientModel.SetButtonLoader(buttonLoader)
+	buttonLoader.Get("classList").Call("add", "loading")
+	button.Call("appendChild", buttonLoader)
 }
 
 func addClass(element js.Value, class string) {

--- a/internal/model/game.go
+++ b/internal/model/game.go
@@ -290,6 +290,63 @@ func (game *Game) Result() GameResult {
 	return game.result
 }
 
+// PreviousMover get the game's previous mover
+func (game *Game) PreviousMover() *Piece {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.previousMover
+}
+
+// PreviousMove get the game's previous move
+func (game *Game) PreviousMove() Move {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.previousMove
+}
+
+// BlackKing get the game's black king
+func (game *Game) BlackKing() *Piece {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.blackKing
+}
+
+// WhiteKing get the game's white king
+func (game *Game) WhiteKing() *Piece {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.whiteKing
+}
+
+// WhitePieces get the game's white pieces
+func (game *Game) WhitePieces() map[PieceType]uint8 {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.whitePieces
+}
+
+// BlackPieces get the game's black pieces
+func (game *Game) BlackPieces() map[PieceType]uint8 {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.blackPieces
+}
+
+// PositionHistory get the game's position history
+func (game *Game) PositionHistory() map[string]uint8 {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.positionHistory
+}
+
+// TurnsSinceCaptureOrPawnMove get the game's number of turns since a capture or
+// pawn move
+func (game *Game) TurnsSinceCaptureOrPawnMove() uint8 {
+	game.mutex.RLock()
+	defer game.mutex.RUnlock()
+	return game.turnsSinceCaptureOrPawnMove
+}
+
 func (mr MoveRequest) String() string {
 	return "Position: " + mr.Position.String() + ", Move: " + mr.Move.String()
 }

--- a/internal/model/game.go
+++ b/internal/model/game.go
@@ -201,27 +201,17 @@ func NewGame() *Game {
 // NewCustomGame create a new custom game
 func NewCustomGame(serializableBoard SerializableBoard,
 	blackKing Piece, whiteKing Piece, positionHistory map[string]uint8,
-	blackPieces map[PieceType]uint8, whitePieces map[PieceType]uint8) *Game {
+	blackPieces map[PieceType]uint8, whitePieces map[PieceType]uint8,
+	turn Color, gameOver bool, result GameResult, previousMove Move,
+	previousMover Piece, turnsSinceCaptureOrPawnMove uint8) *Game {
 	board := newBoardFromSerializableBoard(serializableBoard)
 	game := Game{
-		board: board, blackKing: board[blackKing.File()][blackKing.Rank()],
-		whiteKing:       board[whiteKing.File()][whiteKing.Rank()],
-		positionHistory: positionHistory,
-		blackPieces:     blackPieces, whitePieces: whitePieces,
+		board, turn, gameOver, result, previousMove, &previousMover,
+		board[blackKing.File()][blackKing.Rank()],
+		board[whiteKing.File()][whiteKing.Rank()],
+		whitePieces, blackPieces, positionHistory, turnsSinceCaptureOrPawnMove,
+		sync.RWMutex{},
 	}
-	for _, file := range board {
-		for _, piece := range file {
-			if piece != nil {
-				if piece.Color == Black {
-					game.blackPieces[piece.PieceType]++
-				} else {
-					game.whitePieces[piece.PieceType]++
-				}
-			}
-		}
-	}
-	game.updatePositionHistory()
-	game.turn = White
 	return &game
 }
 

--- a/internal/model/game_test.go
+++ b/internal/model/game_test.go
@@ -13,8 +13,12 @@ func TestNewGame(t *testing.T) {
 	if game.turn != White {
 		t.Error("Expected turn = ", White, " got ", game.turn)
 	}
-	if game.blackKing.pieceType != King || game.whiteKing.pieceType != King {
-		t.Error("Expected kings got ", game.blackKing.pieceType)
+	if game.blackKing.PieceType != King || game.whiteKing.PieceType != King {
+		t.Error("Expected kings got ", game.blackKing.PieceType)
+	}
+	board := game.GetSerializableBoard()
+	if board[1].Position == board[10].Position {
+		t.Error("Expected a serializable board got", game.GetSerializableBoard())
 	}
 }
 
@@ -186,14 +190,14 @@ func TestPromotion(t *testing.T) {
 	game.Move(MoveRequest{Position{4, 5}, Move{1, 1}, nil})
 	game.Move(MoveRequest{Position{4, 7}, Move{-1, -1}, nil})
 	err := game.Move(MoveRequest{Position{5, 6}, Move{1, 1}, nil})
-	if err == nil || game.board[6][7].PieceType() != Knight {
+	if err == nil || game.board[6][7].PieceType != Knight {
 		t.Error("Pawn should not have moved since the move is invalid without promotion.")
 	}
 	game.Move(MoveRequest{Position{5, 6}, Move{1, 1}, &promotionType})
 	if debug {
 		fmt.Println(game.board)
 	}
-	if game.board[6][7] == nil || game.board[6][7].PieceType() != Rook {
+	if game.board[6][7] == nil || game.board[6][7].PieceType != Rook {
 		t.Error("Pawn should have been promoted")
 	}
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -19,7 +19,8 @@ type (
 	}
 
 	// Board is a chess board of pieces
-	Board             [8][8]*Piece
+	Board [8][8]*Piece
+	// SerializableBoard is a chess board of pieces that can be serialized
 	SerializableBoard []Piece
 )
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -62,7 +62,8 @@ func newBoardNoPawns() Board {
 func newBoardFromSerializableBoard(serializableBoard SerializableBoard) *Board {
 	var board Board
 	for _, piece := range serializableBoard {
-		board[piece.File()][piece.Rank()] = &piece
+		pieceCopy := piece
+		board[piece.File()][piece.Rank()] = &pieceCopy
 	}
 	return &board
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -19,7 +19,8 @@ type (
 	}
 
 	// Board is a chess board of pieces
-	Board [8][8]*Piece
+	Board             [8][8]*Piece
+	SerializableBoard []Piece
 )
 
 // NewPosition creates a new position
@@ -44,7 +45,7 @@ func newFullBoard() Board {
 			rank = 1
 		}
 		piece := NewPiece(Pawn, NewPosition(uint8(i%8), rank), color)
-		board[piece.position.File][piece.position.Rank] = piece
+		board[piece.Position.File][piece.Position.Rank] = piece
 	}
 	// Create the rest.
 	createTheBackLine(&board)
@@ -55,6 +56,14 @@ func newBoardNoPawns() Board {
 	var board Board
 	createTheBackLine(&board)
 	return board
+}
+
+func newBoardFromSerializableBoard(serializableBoard SerializableBoard) *Board {
+	var board Board
+	for _, piece := range serializableBoard {
+		board[piece.File()][piece.Rank()] = &piece
+	}
+	return &board
 }
 
 func createTheBackLine(board *Board) {

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -8,18 +8,18 @@ func TestNewBoard(t *testing.T) {
 	board := newFullBoard()
 	for file := 0; file < 8; file++ {
 		blackPawn := board[file][6]
-		if blackPawn.PieceType() != Pawn {
-			t.Error("Expected pieceType = ", Pawn, " got ", blackPawn.PieceType())
+		if blackPawn.PieceType != Pawn {
+			t.Error("Expected pieceType = ", Pawn, " got ", blackPawn.PieceType)
 		}
-		if blackPawn.Color() != Black {
-			t.Error("Expected color = ", Black, " got ", blackPawn.Color())
+		if blackPawn.Color != Black {
+			t.Error("Expected color = ", Black, " got ", blackPawn.Color)
 		}
 		whitePawn := board[file][1]
-		if whitePawn.PieceType() != Pawn {
-			t.Error("Expected pieceType = ", Pawn, " got ", whitePawn.PieceType())
+		if whitePawn.PieceType != Pawn {
+			t.Error("Expected pieceType = ", Pawn, " got ", whitePawn.PieceType)
 		}
-		if whitePawn.Color() != White {
-			t.Error("Expected color = ", White, " got ", whitePawn.Color())
+		if whitePawn.Color != White {
+			t.Error("Expected color = ", White, " got ", whitePawn.Color)
 		}
 	}
 }

--- a/internal/model/move.go
+++ b/internal/model/move.go
@@ -56,7 +56,7 @@ func (piece *Piece) takeMove(
 		piece.takeMoveUnsafe(
 			board, move, previousMove, previousMover, promoteTo,
 		)
-	piece.movesTaken++
+	piece.MovesTaken++
 	return capturedPiece, nil
 }
 
@@ -68,7 +68,7 @@ func (piece *Piece) takeMoveUnsafe(
 	newCastledPosition Position, castledRook *Piece,
 ) {
 	yDirection := int8(1)
-	if piece.Color() == Black {
+	if piece.Color == Black {
 		yDirection *= -1
 	}
 	newX, newY := addMoveToPosition(piece, move)
@@ -77,13 +77,13 @@ func (piece *Piece) takeMoveUnsafe(
 	if newX <= 7 && enPassantTargetY <= 7 {
 		enPassantTarget = board[newX][enPassantTargetY]
 	}
-	isEnPassant := (piece.pieceType == Pawn && newX != piece.File() &&
+	isEnPassant := (piece.PieceType == Pawn && newX != piece.File() &&
 		enPassantTarget != nil && enPassantTarget == previousMover &&
-		enPassantTarget.pieceType == Pawn &&
+		enPassantTarget.PieceType == Pawn &&
 		(previousMove.Y == 2 || previousMove.Y == -2) &&
 		piece.Rank() == enPassantTargetY &&
-		piece.Color() != enPassantTarget.Color())
-	isCastle := piece.pieceType == King && (move.X < -1 || move.X > 1)
+		piece.Color != enPassantTarget.Color)
+	isCastle := piece.PieceType == King && (move.X < -1 || move.X > 1)
 	if isEnPassant {
 		capturedPiece = board[enPassantTarget.File()][enPassantTarget.Rank()]
 		board[enPassantTarget.File()][enPassantTarget.Rank()] = nil
@@ -96,9 +96,9 @@ func (piece *Piece) takeMoveUnsafe(
 	board[newX][newY] = piece
 	board[piece.File()][piece.Rank()] = nil
 	newPosition = Position{newX, newY}
-	piece.position = newPosition
+	piece.Position = newPosition
 	if promoteTo != nil {
-		piece.pieceType = *promoteTo
+		piece.PieceType = *promoteTo
 	}
 	return newPosition, capturedPiece, newCastledPosition, castledRook
 }
@@ -128,15 +128,15 @@ func (piece *Piece) ValidMoves(
 	allThreatened bool, king *Piece,
 ) []Move {
 	validMoves := []Move{}
-	baseMoves := moveMap[piece.PieceType()]
+	baseMoves := moveMap[piece.PieceType]
 	canSlideCapture := true
-	if piece.PieceType() == Pawn {
+	if piece.PieceType == Pawn {
 		canSlideCapture = false
 	}
 	for _, baseMove := range baseMoves {
 		validMoves = append(validMoves, piece.validMovesSlide(
 			baseMove, previousMove, previousMover, board,
-			maxSlideMap[piece.PieceType()], canSlideCapture,
+			maxSlideMap[piece.PieceType], canSlideCapture,
 			allThreatened, king,
 		)...)
 	}
@@ -154,7 +154,7 @@ func (piece *Piece) promotionValid(move Move, promoteTo *PieceType) bool {
 		Rook: {}, Queen: {},
 	}
 	_, newY := addMoveToPosition(piece, move)
-	if piece.PieceType() == Pawn {
+	if piece.PieceType == Pawn {
 		if promoteTo == nil {
 			return newY != 7 && newY != 0
 		}
@@ -179,8 +179,8 @@ func (piece *Piece) getCastleMove(
 }
 
 func addMoveToPosition(piece *Piece, move Move) (uint8, uint8) {
-	newX := uint8(int8(piece.Position().File) + move.X)
-	newY := uint8(int8(piece.Position().Rank) + move.Y)
+	newX := uint8(int8(piece.Position.File) + move.X)
+	newY := uint8(int8(piece.Position.Rank) + move.Y)
 	return newX, newY
 }
 
@@ -196,7 +196,7 @@ func (piece *Piece) validCaptureMovesPawn(
 	king *Piece,
 ) []Move {
 	yDirection := int8(1)
-	if piece.Color() == Black {
+	if piece.Color == Black {
 		yDirection *= -1
 	}
 	captureMoves := []Move{}
@@ -215,7 +215,7 @@ func (piece *Piece) validCaptureMovesPawn(
 		enPassantTarget := board[newX][newY+uint8(-1*yDirection)]
 		canEnPassant :=
 			piece.canEnPassant(previousMove, previousMover, enPassantTarget)
-		canCapture := pieceAtDest != nil && pieceAtDest.Color() != piece.Color()
+		canCapture := pieceAtDest != nil && pieceAtDest.Color != piece.Color
 		if canCapture || canEnPassant || allThreatened {
 			captureMoves = append(captureMoves, captureMove)
 		}
@@ -227,8 +227,8 @@ func (piece *Piece) canEnPassant(
 	previousMove Move, previousMover *Piece, enPassantTarget *Piece,
 ) bool {
 	return enPassantTarget != nil && enPassantTarget == previousMover &&
-		enPassantTarget.Color() != piece.Color() &&
-		enPassantTarget.pieceType == Pawn &&
+		enPassantTarget.Color != piece.Color &&
+		enPassantTarget.PieceType == Pawn &&
 		(previousMove.Y == 2 || previousMove.Y == -2)
 }
 
@@ -238,11 +238,11 @@ func (piece *Piece) validMovesSlide(
 ) []Move {
 	validSlides := []Move{}
 	yDirectionModifier := int8(1)
-	if piece.PieceType() == Pawn {
-		if piece.Color() == Black {
+	if piece.PieceType == Pawn {
+		if piece.Color == Black {
 			yDirectionModifier = int8(-1)
 		}
-		if piece.movesTaken > 0 {
+		if piece.MovesTaken > 0 {
 			maxSlide = 1
 		}
 		validSlides = append(
@@ -273,11 +273,11 @@ func (piece *Piece) validMovesSlide(
 				break
 			}
 		}
-		if destIsValidNoCapture && (piece.pieceType != Pawn || !allThreatened) {
+		if destIsValidNoCapture && (piece.PieceType != Pawn || !allThreatened) {
 			validSlides = append(validSlides, slideMove)
 		} else {
 			destIsValidCapture :=
-				canSlideCapture && pieceAtDest.Color() != piece.Color()
+				canSlideCapture && pieceAtDest.Color != piece.Color
 			if destIsValidCapture {
 				validSlides = append(validSlides, slideMove)
 			}
@@ -296,7 +296,7 @@ func AllMoves(
 	// for each enemy piece
 	for _, file := range board {
 		for _, piece := range file {
-			if piece != nil && piece.color == color {
+			if piece != nil && piece.Color == color {
 				for _, position := range piece.Moves(
 					board, previousMove, previousMover, allThreatened, king,
 				) {
@@ -338,7 +338,7 @@ func (piece *Piece) handleCastle(
 		castledRook = board[5][piece.Rank()]
 		newCastledPosition = Position{5, piece.Rank()}
 	}
-	castledRook.position = newCastledPosition
+	castledRook.Position = newCastledPosition
 	return castledRook, newCastledPosition
 }
 
@@ -353,7 +353,7 @@ func (piece *Piece) canCastle(
 	if !noBlockLeft && !noBlockRight {
 		return false, false
 	}
-	enemyColor := getOppositeColor(piece.color)
+	enemyColor := getOppositeColor(piece.Color)
 	threatenedPositions := AllMoves(
 		board, enemyColor, previousMove, previousMover, true, nil,
 	)
@@ -365,13 +365,13 @@ func (piece *Piece) canCastle(
 }
 
 func (piece *Piece) hasCastleRights(board *Board) (castleLeft, castleRight bool) {
-	if piece.pieceType != King || piece.movesTaken > 0 {
+	if piece.PieceType != King || piece.MovesTaken > 0 {
 		return false, false
 	}
 	rookPieces := [2]*Piece{board[0][piece.Rank()], board[7][piece.Rank()]}
 	castleLeft, castleRight = true, true
 	for i, rook := range rookPieces {
-		if rook == nil || rook.pieceType != Rook || rook.movesTaken != 0 {
+		if rook == nil || rook.PieceType != Rook || rook.MovesTaken != 0 {
 			if i == 0 {
 				castleLeft = false
 			} else {
@@ -421,7 +421,7 @@ func (piece *Piece) wouldBeInCheck(
 	if king == nil {
 		return false
 	}
-	originalPosition := piece.position
+	originalPosition := piece.Position
 	newPosition, capturedPiece, newCastledPosition, castledRook :=
 		piece.takeMoveUnsafe(board, move, previousMove, previousMover, nil)
 	wouldBeInCheck := king.isThreatened(board, move, piece)
@@ -431,14 +431,14 @@ func (piece *Piece) wouldBeInCheck(
 		board[capturedPiece.File()][capturedPiece.Rank()] = capturedPiece
 	}
 	board[originalPosition.File][originalPosition.Rank] = piece
-	piece.position = originalPosition
+	piece.Position = originalPosition
 	if castledRook != nil {
 		board[newCastledPosition.File][newCastledPosition.Rank] = nil
 		board[newCastledPosition.File][newCastledPosition.Rank] = nil
-		if castledRook.position.File == 5 {
-			castledRook.position.File = 7
+		if castledRook.Position.File == 5 {
+			castledRook.Position.File = 7
 		} else {
-			castledRook.position.File = 0
+			castledRook.Position.File = 0
 		}
 	}
 	return wouldBeInCheck
@@ -448,14 +448,14 @@ func (piece *Piece) isThreatened(board *Board, previousMove Move,
 	previousMover *Piece,
 ) bool {
 	enemyColor := Black
-	if piece.color == Black {
+	if piece.Color == Black {
 		enemyColor = White
 	}
 	threatenedPositions := AllMoves(
 		board, enemyColor, previousMove, previousMover, true, nil,
 	)
 	inCheck := false
-	if threatenedPositions[piece.position] {
+	if threatenedPositions[piece.Position] {
 		inCheck = true
 	}
 	return inCheck

--- a/internal/model/piece.go
+++ b/internal/model/piece.go
@@ -8,10 +8,10 @@ import (
 type (
 	// Piece a chess piece
 	Piece struct {
-		pieceType  PieceType
-		position   Position
-		color      Color
-		movesTaken uint16
+		PieceType  PieceType
+		Position   Position
+		Color      Color
+		MovesTaken uint16
 	}
 
 	// PieceType the various piece types
@@ -43,34 +43,34 @@ func (piece *Piece) String() string {
 	if piece == nil {
 		return "-"
 	}
-	switch piece.pieceType {
+	switch piece.PieceType {
 	case Rook:
-		if piece.Color() == White {
+		if piece.Color == White {
 			return "\u2656"
 		}
 		return "\u265C"
 	case Knight:
-		if piece.Color() == White {
+		if piece.Color == White {
 			return "\u2658"
 		}
 		return "\u265E"
 	case Bishop:
-		if piece.Color() == White {
+		if piece.Color == White {
 			return "\u2657"
 		}
 		return "\u265D"
 	case Queen:
-		if piece.Color() == White {
+		if piece.Color == White {
 			return "\u2655"
 		}
 		return "\u265B"
 	case King:
-		if piece.Color() == White {
+		if piece.Color == White {
 			return "\u2654"
 		}
 		return "\u265A"
 	case Pawn:
-		if piece.Color() == White {
+		if piece.Color == White {
 			return "\u2659"
 		}
 		return "\u265F"
@@ -85,12 +85,12 @@ func (piece *Piece) ClientString() string {
 		return ""
 	}
 	out := ""
-	if piece.Color() == Black {
+	if piece.Color == Black {
 		out += "b"
 	} else {
 		out += "w"
 	}
-	switch piece.pieceType {
+	switch piece.PieceType {
 	case Rook:
 		out += "r"
 	case Knight:
@@ -112,7 +112,7 @@ func (piece *Piece) Value() int8 {
 	if piece == nil {
 		return 0
 	}
-	switch piece.pieceType {
+	switch piece.PieceType {
 	case Queen:
 		return 9
 	case Rook:
@@ -132,11 +132,11 @@ func (piece *Piece) MarshalBinary(
 	// Ensure temporary options (castle/en passant) are taken into account
 	// for draw by repetition.
 	temporaryMoveRights := uint8(0)
-	if piece.pieceType == Pawn {
+	if piece.PieceType == Pawn {
 		validMoves :=
 			piece.ValidMoves(board, previousMove, previousMover, false, king)
 		temporaryMoveRights = uint8(len(validMoves))
-	} else if piece.pieceType == King {
+	} else if piece.PieceType == King {
 		castleLeft, castleRight := piece.hasCastleRights(board)
 		if castleLeft {
 			temporaryMoveRights++
@@ -147,10 +147,10 @@ func (piece *Piece) MarshalBinary(
 	}
 	buf := new(bytes.Buffer)
 	err = binary.Write(buf, binary.BigEndian, []byte{
-		byte(piece.pieceType),
-		byte(piece.color),
-		piece.position.File,
-		piece.position.Rank,
+		byte(piece.PieceType),
+		byte(piece.Color),
+		piece.Position.File,
+		piece.Position.Rank,
 		temporaryMoveRights,
 	})
 	return buf.Bytes(), err
@@ -165,10 +165,10 @@ func (piece *Piece) StringSimple() string {
 	colorWhite := "\033[37m"
 	colorReset := "\033[0m"
 	out := colorPurple
-	if piece.Color() == White {
+	if piece.Color == White {
 		out = colorWhite
 	}
-	switch piece.pieceType {
+	switch piece.PieceType {
 	case Rook:
 		out += "r"
 	case Knight:
@@ -185,27 +185,12 @@ func (piece *Piece) StringSimple() string {
 	return out + colorReset
 }
 
-// Position return the piece's position
-func (piece *Piece) Position() Position {
-	return piece.position
-}
-
 // File return the piece's file
 func (piece *Piece) File() uint8 {
-	return piece.position.File
+	return piece.Position.File
 }
 
 // Rank return the piece's rank
 func (piece *Piece) Rank() uint8 {
-	return piece.position.Rank
-}
-
-// PieceType return the piece's type
-func (piece *Piece) PieceType() PieceType {
-	return piece.pieceType
-}
-
-// Color return the piece's color
-func (piece *Piece) Color() Color {
-	return piece.color
+	return piece.Position.Rank
 }

--- a/internal/model/piece_test.go
+++ b/internal/model/piece_test.go
@@ -8,8 +8,8 @@ import (
 func movePiece(board *Board, oldX uint8, oldY uint8, newX uint8, newY uint8) {
 	board[newX][newY] = board[oldX][oldY]
 	board[oldX][oldY] = nil
-	board[newX][newY].position.File = newX
-	board[newX][newY].position.Rank = newY
+	board[newX][newY].Position.File = newX
+	board[newX][newY].Position.Rank = newY
 }
 
 func TestValidMovesPawnUnmoved(t *testing.T) {
@@ -52,7 +52,7 @@ func TestValidMovesPawnEnPassant(t *testing.T) {
 	if debug {
 		fmt.Println(board)
 	}
-	if board[3][3] == nil || board[3][3].Position().Rank != 3 {
+	if board[3][3] == nil || board[3][3].Position.Rank != 3 {
 		t.Error("Expected pawn in the correct position")
 	}
 	validMoves :=

--- a/internal/server/backend/http/webserver.go
+++ b/internal/server/backend/http/webserver.go
@@ -109,6 +109,8 @@ func makeAsyncHandler() http.Handler {
 			}
 			if asyncUpdate.GameOver {
 				player.ClientDoneWithMatch()
+				// player.Reset() TODO should player reset itself instead of
+				// match server
 			}
 		case "POST":
 			var requestAsync matchserver.RequestAsync

--- a/internal/server/backend/http/webserver.go
+++ b/internal/server/backend/http/webserver.go
@@ -108,9 +108,8 @@ func makeAsyncHandler() http.Handler {
 				return
 			}
 			if asyncUpdate.GameOver {
-				player.ClientDoneWithMatch()
-				// player.Reset() TODO should player reset itself instead of
-				// match server
+				player.WaitForMatchOver()
+				player.Reset()
 			}
 		case "POST":
 			var requestAsync matchserver.RequestAsync

--- a/internal/server/backend/http/webserver.go
+++ b/internal/server/backend/http/webserver.go
@@ -47,13 +47,6 @@ func makeSearchForMatchHandler(
 		defer cancel()
 		if player.HasMatchStarted(ctx) {
 			player.SetSearchingForMatch(false)
-			matchResponse :=
-				matchserver.MatchedResponse{
-					Color:        player.Color(),
-					OpponentName: player.MatchedOpponentName(),
-					MaxTimeMs:    player.MatchMaxTimeMs(),
-				}
-			json.NewEncoder(w).Encode(matchResponse)
 		} else {
 			// Return HTTP 202 until match starts.
 			w.WriteHeader(http.StatusAccepted)

--- a/internal/server/backend/http/webserver_test.go
+++ b/internal/server/backend/http/webserver_test.go
@@ -263,7 +263,7 @@ func TestCurrentMatch(t *testing.T) {
 		t.Error(err)
 	}
 	defer resp.Body.Close()
-	var currentMatchResponse gateway.CurrentMatchResponse
+	var currentMatchResponse gateway.SessionResponse
 	json.NewDecoder(resp.Body).Decode(&currentMatchResponse)
 	if debug {
 		fmt.Println(currentMatchResponse)
@@ -287,7 +287,7 @@ func TestCurrentMatchWithGame(t *testing.T) {
 		t.Error(err)
 	}
 	defer resp.Body.Close()
-	var currentMatchResponse gateway.CurrentMatchResponse
+	var currentMatchResponse gateway.SessionResponse
 	json.NewDecoder(resp.Body).Decode(&currentMatchResponse)
 	if debug {
 		fmt.Println(currentMatchResponse)

--- a/internal/server/backend/http/webserver_test.go
+++ b/internal/server/backend/http/webserver_test.go
@@ -297,7 +297,6 @@ func TestCurrentMatchWithGame(t *testing.T) {
 	if resp.StatusCode != 200 || err != nil ||
 		currentMatchResponse.Credentials.Username != blackName ||
 		currentMatchResponse.Match.GameOver == true {
-		println(resp.StatusCode)
 		t.Error("Expected cookies")
 	}
 }

--- a/internal/server/backend/http/webserver_test.go
+++ b/internal/server/backend/http/webserver_test.go
@@ -25,7 +25,6 @@ var (
 	serverSync         *httptest.Server
 	serverAsync        *httptest.Server
 	serverMatchTimeout *httptest.Server
-	currentMatch       *httptest.Server
 )
 
 func init() {

--- a/internal/server/backend/match/engine_client.go
+++ b/internal/server/backend/match/engine_client.go
@@ -72,7 +72,8 @@ func (matchingServer *MatchingServer) engineSession(botPlayer *Player) {
 		case <-gameOver:
 			stream.CloseSend()
 			<-waitc
-			botPlayer.ClientDoneWithMatch()
+			botPlayer.WaitForMatchOver()
+			botPlayer.Reset()
 			return
 		}
 	}

--- a/internal/server/backend/match/engine_client.go
+++ b/internal/server/backend/match/engine_client.go
@@ -61,7 +61,7 @@ func (matchingServer *MatchingServer) engineSession(botPlayer *Player) {
 		// TODO resign in this case?
 		return
 	}
-	gameOver := botPlayer.match.gameOver
+	gameOver := botPlayer.match.gameOverChan
 	waitc := make(chan struct{})
 	go engineReceiveLoop(matchingServer, botPlayer, stream, waitc)
 	for {

--- a/internal/server/backend/match/match.go
+++ b/internal/server/backend/match/match.go
@@ -96,7 +96,6 @@ func (match *Match) PlayerRemainingTimeMs(color model.Color) int64 {
 func (match *Match) GameOver() bool {
 	match.mutex.RLock()
 	defer match.mutex.RUnlock()
-	println(match.Game)
 	return match.Game.GameOver()
 }
 

--- a/internal/server/backend/match/match.go
+++ b/internal/server/backend/match/match.go
@@ -83,6 +83,13 @@ func (match *Match) PlayerName(color model.Color) string {
 	return match.white.Name()
 }
 
+// MaxTimeMs get match max time
+func (match *Match) MaxTimeMs() int64 {
+	match.mutex.RLock()
+	defer match.mutex.RUnlock()
+	return match.maxTimeMs
+}
+
 // PlayerRemainingTimeMs get the player corresponding to the input color
 func (match *Match) PlayerRemainingTimeMs(color model.Color) int64 {
 	match.mutex.RLock()

--- a/internal/server/backend/match/match.go
+++ b/internal/server/backend/match/match.go
@@ -14,8 +14,8 @@ type (
 	Match struct {
 		black         *Player
 		white         *Player
-		game          *model.Game
-		gameOver      chan struct{}
+		Game          *model.Game
+		gameOverChan  chan struct{}
 		maxTimeMs     int64
 		requestedDraw *Player
 		mutex         sync.RWMutex
@@ -82,11 +82,22 @@ func (match *Match) PlayerName(color model.Color) string {
 	return match.white.Name()
 }
 
+// PlayerRemainingTimeMs get the player corresponding to the input color
+func (match *Match) PlayerRemainingTimeMs(color model.Color) int64 {
+	match.mutex.RLock()
+	defer match.mutex.RUnlock()
+	if color == model.Black {
+		return match.maxTimeMs - match.black.elapsedMs
+	}
+	return match.maxTimeMs - match.white.elapsedMs
+}
+
 // GameOver check if the game is over
 func (match *Match) GameOver() bool {
 	match.mutex.RLock()
 	defer match.mutex.RUnlock()
-	return match.game.GameOver()
+	println(match.Game)
+	return match.Game.GameOver()
 }
 
 // GetRequestedDraw get the current player who has requested a draw
@@ -103,15 +114,10 @@ func (match *Match) SetRequestedDraw(player *Player) {
 	match.requestedDraw = player
 }
 
-// MaxTimeMs return the match's max time
-func (match *Match) MaxTimeMs() int64 {
-	return match.maxTimeMs
-}
-
 func (match *Match) play() {
 	waitc := make(chan struct{})
 	go match.handleAsyncRequests(waitc)
-	for !match.game.GameOver() {
+	for !match.Game.GameOver() {
 		match.handleTurn()
 	}
 	<-waitc
@@ -124,7 +130,7 @@ func (match *Match) play() {
 func (match *Match) handleTurn() {
 	player := match.black
 	opponent := match.white
-	if match.game.Turn() != model.Black {
+	if match.Game.Turn() != model.Black {
 		player = match.white
 		opponent = match.black
 	}
@@ -136,21 +142,21 @@ func (match *Match) handleTurn() {
 	request := model.MoveRequest{}
 	select {
 	case request = <-player.requestChanSync:
-	case <-match.gameOver:
+	case <-match.gameOverChan:
 		return
 	}
 	err := errors.New("")
 	for err != nil {
-		err = match.game.Move(request)
+		err = match.Game.Move(request)
 		if err != nil {
 			select {
 			case player.ResponseChanSync <- ResponseSync{MoveSuccess: false}:
-			case <-match.gameOver:
+			case <-match.gameOverChan:
 				return
 			}
 			select {
 			case request = <-player.requestChanSync:
-			case <-match.gameOver:
+			case <-match.gameOverChan:
 				return
 			}
 		}
@@ -165,8 +171,8 @@ func (match *Match) handleTurn() {
 		ElapsedMsOpponent: int(opponent.elapsedMs),
 	}
 	opponent.OpponentPlayedMove <- request
-	if match.game.GameOver() {
-		result := match.game.Result()
+	if match.Game.GameOver() {
+		result := match.Game.Result()
 		winner := match.black
 		if result.Winner == model.White {
 			winner = match.white
@@ -177,9 +183,9 @@ func (match *Match) handleTurn() {
 
 func (match *Match) handleTimeout(opponent *Player) func() {
 	return func() {
-		onlyKing := match.game.OnlyKing(model.Black)
+		onlyKing := match.Game.OnlyKing(model.Black)
 		if opponent.color == model.White {
-			onlyKing = match.game.OnlyKing(model.White)
+			onlyKing = match.Game.OnlyKing(model.White)
 		}
 		if onlyKing {
 			match.handleGameOver(true, false, true, opponent)
@@ -191,7 +197,7 @@ func (match *Match) handleTimeout(opponent *Player) func() {
 
 func (match *Match) handleAsyncRequests(waitc chan struct{}) {
 	defer close(waitc)
-	for !match.game.GameOver() {
+	for !match.Game.GameOver() {
 		opponent := match.white
 		player := match.black
 		request := RequestAsync{}
@@ -200,7 +206,7 @@ func (match *Match) handleAsyncRequests(waitc chan struct{}) {
 		case request = <-match.white.RequestChanAsync:
 			opponent = match.black
 			player = match.white
-		case <-match.gameOver:
+		case <-match.gameOverChan:
 			return
 		}
 		if request.Resign {
@@ -217,7 +223,7 @@ func (match *Match) handleAsyncRequests(waitc chan struct{}) {
 					case opponent.ResponseChanAsync <- ResponseAsync{
 						false, true, false, false, false, "",
 					}:
-					case <-match.gameOver:
+					case <-match.gameOverChan:
 					}
 				}()
 			} else {
@@ -227,7 +233,7 @@ func (match *Match) handleAsyncRequests(waitc chan struct{}) {
 					case opponent.ResponseChanAsync <- ResponseAsync{
 						false, true, false, false, false, "",
 					}:
-					case <-match.gameOver:
+					case <-match.gameOverChan:
 					}
 				}()
 			}
@@ -241,12 +247,12 @@ func (match *Match) handleGameOver(
 	match.mutex.Lock()
 	defer match.mutex.Unlock()
 	select {
-	case <-match.gameOver:
+	case <-match.gameOverChan:
 		return
 	default:
 		break
 	}
-	match.game.SetGameResult(winner.color, draw)
+	match.Game.SetGameResult(winner.color, draw)
 	winnerName := winner.name
 	if draw {
 		winnerName = ""
@@ -266,5 +272,5 @@ func (match *Match) handleGameOver(
 		}()
 	}
 	wg.Wait()
-	close(match.gameOver)
+	close(match.gameOverChan)
 }

--- a/internal/server/backend/match/match.go
+++ b/internal/server/backend/match/match.go
@@ -120,6 +120,7 @@ func (match *Match) play() {
 		match.handleTurn()
 	}
 	<-waitc
+	/* TODO maybe let client servers reset the clients? */
 	match.black.WaitForClientToBeDoneWithMatch()
 	match.white.WaitForClientToBeDoneWithMatch()
 	match.black.Reset()

--- a/internal/server/backend/match/match.go
+++ b/internal/server/backend/match/match.go
@@ -221,7 +221,7 @@ func (match *Match) handleAsyncRequests(waitc chan struct{}) {
 				go func() {
 					select {
 					case opponent.ResponseChanAsync <- ResponseAsync{
-						false, true, false, false, false, "",
+						false, true, false, false, false, false, "", MatchDetails{},
 					}:
 					case <-match.gameOverChan:
 					}
@@ -231,7 +231,7 @@ func (match *Match) handleAsyncRequests(waitc chan struct{}) {
 				go func() {
 					select {
 					case opponent.ResponseChanAsync <- ResponseAsync{
-						false, true, false, false, false, "",
+						false, true, false, false, false, false, "", MatchDetails{},
 					}:
 					case <-match.gameOverChan:
 					}

--- a/internal/server/backend/match/matchserver.go
+++ b/internal/server/backend/match/matchserver.go
@@ -85,6 +85,7 @@ type (
 		matchMutex         sync.RWMutex
 		searchingForMatch  bool
 		match              *Match
+		clientMutex        sync.Mutex // Only one client connected at a time
 	}
 )
 
@@ -126,6 +127,18 @@ func (player *Player) SetMatch(match *Match) {
 	player.matchMutex.Lock()
 	defer player.matchMutex.Unlock()
 	player.match = match
+}
+
+// ClientConnectToMatch ensures that only one client is connected to the player
+// at a time (even if two client's have the session token)
+func (player *Player) ClientConnectToMatch() {
+	player.clientMutex.Lock()
+}
+
+// ClientDisconnectFromMatch ensures that only one client is connected to the
+// player at a time (even if two client's have the session token)
+func (player *Player) ClientDisconnectFromMatch() {
+	player.clientMutex.Unlock()
 }
 
 // MatchedOpponentName returns the matched opponent name

--- a/internal/server/backend/match/matchserver.go
+++ b/internal/server/backend/match/matchserver.go
@@ -145,7 +145,7 @@ func (player *Player) MatchedOpponentName() string {
 
 // MatchMaxTimeMs returns players max time in ms
 func (player *Player) MatchMaxTimeMs() int64 {
-	return player.GetMatch().MaxTimeMs()
+	return player.GetMatch().maxTimeMs
 }
 
 // Color returns player color

--- a/internal/server/backend/match/matchserver.go
+++ b/internal/server/backend/match/matchserver.go
@@ -129,15 +129,15 @@ func (player *Player) SetMatch(match *Match) {
 	player.match = match
 }
 
-// ClientConnectToMatch ensures that only one client is connected to the player
+// ClientConnectToPlayer ensures that only one client is connected to the player
 // at a time (even if two client's have the session token)
-func (player *Player) ClientConnectToMatch() {
+func (player *Player) ClientConnectToPlayer() {
 	player.clientMutex.Lock()
 }
 
-// ClientDisconnectFromMatch ensures that only one client is connected to the
+// ClientDisconnectFromPlayer ensures that only one client is connected to the
 // player at a time (even if two client's have the session token)
-func (player *Player) ClientDisconnectFromMatch() {
+func (player *Player) ClientDisconnectFromPlayer() {
 	player.clientMutex.Unlock()
 }
 

--- a/internal/server/backend/match/matchserver.go
+++ b/internal/server/backend/match/matchserver.go
@@ -71,21 +71,20 @@ type (
 	// Player is a struct representing a matchserver client, containing channels
 	// for communications between the client and the the matchserver
 	Player struct {
-		name                string
-		color               model.Color
-		elapsedMs           int64
-		requestChanSync     chan model.MoveRequest
-		ResponseChanSync    chan ResponseSync
-		RequestChanAsync    chan RequestAsync
-		ResponseChanAsync   chan ResponseAsync
-		OpponentPlayedMove  chan model.MoveRequest
-		matchStart          chan struct{}
-		clientDoneWithMatch chan struct{}
-		ChannelMutex        sync.RWMutex
-		matchStartMutex     sync.RWMutex
-		matchMutex          sync.RWMutex
-		searchingForMatch   bool
-		match               *Match
+		name               string
+		color              model.Color
+		elapsedMs          int64
+		requestChanSync    chan model.MoveRequest
+		ResponseChanSync   chan ResponseSync
+		RequestChanAsync   chan RequestAsync
+		ResponseChanAsync  chan ResponseAsync
+		OpponentPlayedMove chan model.MoveRequest
+		matchStart         chan struct{}
+		ChannelMutex       sync.RWMutex
+		matchStartMutex    sync.RWMutex
+		matchMutex         sync.RWMutex
+		searchingForMatch  bool
+		match              *Match
 	}
 )
 
@@ -166,7 +165,7 @@ func (player *Player) WaitForMatchStart() error {
 
 // WaitForMatchOver used by client servers to synchronize around match ending
 func (player *Player) WaitForMatchOver() {
-	<-player.match.matchOverChan
+	player.match.waitForMatchOver()
 }
 
 // HasMatchStarted player checks if their match has started

--- a/internal/server/backend/match/matchserver_test.go
+++ b/internal/server/backend/match/matchserver_test.go
@@ -42,8 +42,10 @@ func TestMatchingServerTimeout(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
-	liveMatch := matchingServer.LiveMatches()[0]
 	response := <-player1.ResponseChanAsync
+	response = <-player2.ResponseChanAsync
+	liveMatch := matchingServer.LiveMatches()[0]
+	response = <-player1.ResponseChanAsync
 	if !liveMatch.Game.GameOver() || !response.GameOver || !response.Timeout {
 		t.Error("Expected timed out game got", response)
 	}
@@ -66,6 +68,8 @@ func TestMatchingServerInsufficientMaterialDraw(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
+	response := <-player1.ResponseChanAsync
+	response = <-player2.ResponseChanAsync
 	liveMatch := matchingServer.LiveMatches()[0]
 	black := liveMatch.black
 	white := liveMatch.white
@@ -174,7 +178,7 @@ func TestMatchingServerInsufficientMaterialDraw(t *testing.T) {
 		Move:      model.Move{X: 0, Y: -1},
 		PromoteTo: nil})
 	black.GetSyncUpdate()
-	response := <-white.ResponseChanAsync
+	response = <-white.ResponseChanAsync
 	if !liveMatch.Game.GameOver() || !response.GameOver ||
 		!response.Draw || response.Timeout {
 		t.Error("Expected draw got", response)
@@ -198,6 +202,8 @@ func TestMatchingServerInsufficientMaterialTimeoutDraw(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
+	response := <-player1.ResponseChanAsync
+	response = <-player2.ResponseChanAsync
 	liveMatch := matchingServer.LiveMatches()[0]
 	black := liveMatch.black
 	white := liveMatch.white
@@ -296,7 +302,7 @@ func TestMatchingServerInsufficientMaterialTimeoutDraw(t *testing.T) {
 		Move:      model.Move{X: -1, Y: 0},
 		PromoteTo: nil})
 	black.GetSyncUpdate()
-	response := <-white.ResponseChanAsync
+	response = <-white.ResponseChanAsync
 	if !liveMatch.Game.GameOver() || !response.GameOver ||
 		!response.Draw || !response.Timeout {
 		t.Error("Expected draw got", response)
@@ -312,6 +318,8 @@ func TestMatchingServerDraw(t *testing.T) {
 	exitChan := make(chan bool, 1)
 	exitChan <- true
 	matchingServer.StartMatchServers(1, exitChan)
+	<-player1.ResponseChanAsync
+	<-player2.ResponseChanAsync
 	player1.RequestChanAsync <- RequestAsync{RequestToDraw: true}
 	response := <-player2.ResponseChanAsync
 	liveMatch := matchingServer.LiveMatches()[0]
@@ -369,6 +377,8 @@ func TestMatchingServerResignation(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
+	<-player1.ResponseChanAsync
+	<-player2.ResponseChanAsync
 	liveMatch := matchingServer.LiveMatches()[0]
 	player1.RequestChanAsync <- RequestAsync{Resign: true}
 	response := <-player1.ResponseChanAsync
@@ -391,6 +401,8 @@ func TestMatchingServerPlayerSecondGame(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
+	<-player1.ResponseChanAsync
+	<-player2.ResponseChanAsync
 	liveMatch := matchingServer.LiveMatches()[0]
 	player1.RequestChanAsync <- RequestAsync{Resign: true}
 	response := <-player1.ResponseChanAsync
@@ -411,6 +423,8 @@ func TestMatchingServerPlayerSecondGame(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
+	<-player1.ResponseChanAsync
+	<-player2.ResponseChanAsync
 	liveMatch = matchingServer.LiveMatches()[0]
 	player1.RequestChanAsync <- RequestAsync{Resign: true}
 	response = <-player1.ResponseChanAsync
@@ -435,6 +449,8 @@ func TestMatchingServerValidMoves(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
+	<-player1.ResponseChanAsync
+	<-player2.ResponseChanAsync
 	liveMatch := matchingServer.LiveMatches()[0]
 	black := liveMatch.black
 	white := liveMatch.white
@@ -466,6 +482,8 @@ func TestMatchingServerInvalidMoves(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
+	<-player1.ResponseChanAsync
+	<-player2.ResponseChanAsync
 	liveMatch := matchingServer.LiveMatches()[0]
 	black := liveMatch.black
 	white := liveMatch.white
@@ -503,6 +521,8 @@ func TestMatchingServerCheckmate(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
+	response := <-player1.ResponseChanAsync
+	response = <-player2.ResponseChanAsync
 	liveMatch := matchingServer.LiveMatches()[0]
 	black := liveMatch.black
 	white := liveMatch.white
@@ -553,7 +573,7 @@ func TestMatchingServerCheckmate(t *testing.T) {
 	if !liveMatch.Game.GameOver() {
 		t.Error("Expected gameover got ", liveMatch)
 	}
-	response := <-black.ResponseChanAsync
+	response = <-black.ResponseChanAsync
 	if !response.GameOver || !(response.Winner == white.name) {
 		t.Error("Expected checkmate got ", response)
 	}

--- a/internal/server/backend/match/matchserver_test.go
+++ b/internal/server/backend/match/matchserver_test.go
@@ -44,7 +44,7 @@ func TestMatchingServerTimeout(t *testing.T) {
 	}
 	liveMatch := matchingServer.LiveMatches()[0]
 	response := <-player1.ResponseChanAsync
-	if !liveMatch.game.GameOver() || !response.GameOver || !response.Timeout {
+	if !liveMatch.Game.GameOver() || !response.GameOver || !response.Timeout {
 		t.Error("Expected timed out game got", response)
 	}
 }
@@ -175,7 +175,7 @@ func TestMatchingServerInsufficientMaterialDraw(t *testing.T) {
 		PromoteTo: nil})
 	black.GetSyncUpdate()
 	response := <-white.ResponseChanAsync
-	if !liveMatch.game.GameOver() || !response.GameOver ||
+	if !liveMatch.Game.GameOver() || !response.GameOver ||
 		!response.Draw || response.Timeout {
 		t.Error("Expected draw got", response)
 	}
@@ -297,7 +297,7 @@ func TestMatchingServerInsufficientMaterialTimeoutDraw(t *testing.T) {
 		PromoteTo: nil})
 	black.GetSyncUpdate()
 	response := <-white.ResponseChanAsync
-	if !liveMatch.game.GameOver() || !response.GameOver ||
+	if !liveMatch.Game.GameOver() || !response.GameOver ||
 		!response.Draw || !response.Timeout {
 		t.Error("Expected draw got", response)
 	}
@@ -349,9 +349,9 @@ func TestMatchingServerDraw(t *testing.T) {
 	}
 	player2.RequestChanAsync <- RequestAsync{RequestToDraw: true}
 	response = <-player2.ResponseChanAsync
-	if !liveMatch.game.GameOver() || !response.GameOver ||
+	if !liveMatch.Game.GameOver() || !response.GameOver ||
 		!response.Draw {
-		t.Error("Expected a draw got ", response.Draw, response.GameOver, liveMatch.game.GameOver())
+		t.Error("Expected a draw got ", response.Draw, response.GameOver, liveMatch.Game.GameOver())
 	}
 }
 
@@ -372,7 +372,7 @@ func TestMatchingServerResignation(t *testing.T) {
 	liveMatch := matchingServer.LiveMatches()[0]
 	player1.RequestChanAsync <- RequestAsync{Resign: true}
 	response := <-player1.ResponseChanAsync
-	if !liveMatch.game.GameOver() || !response.GameOver ||
+	if !liveMatch.Game.GameOver() || !response.GameOver ||
 		!response.Resignation {
 		t.Error("Expected resignation got ", response)
 	}
@@ -401,7 +401,7 @@ func TestMatchingServerPlayerSecondGame(t *testing.T) {
 		time.Sleep(time.Millisecond)
 		tries++
 	}
-	if !liveMatch.game.GameOver() || !response.GameOver ||
+	if !liveMatch.Game.GameOver() || !response.GameOver ||
 		!response.Resignation || len(matchingServer.LiveMatches()) > 0 {
 		t.Error("Expected resignation got ", response.GameOver)
 	}
@@ -414,7 +414,7 @@ func TestMatchingServerPlayerSecondGame(t *testing.T) {
 	liveMatch = matchingServer.LiveMatches()[0]
 	player1.RequestChanAsync <- RequestAsync{Resign: true}
 	response = <-player1.ResponseChanAsync
-	if !liveMatch.game.GameOver() || !response.GameOver ||
+	if !liveMatch.Game.GameOver() || !response.GameOver ||
 		!response.Resignation {
 		t.Error("Expected resignation got ", response)
 	}
@@ -550,7 +550,7 @@ func TestMatchingServerCheckmate(t *testing.T) {
 		Position:  model.Position{File: 7, Rank: 4},
 		Move:      model.Move{X: -2, Y: 2},
 		PromoteTo: nil})
-	if !liveMatch.game.GameOver() {
+	if !liveMatch.Game.GameOver() {
 		t.Error("Expected gameover got ", liveMatch)
 	}
 	response := <-black.ResponseChanAsync

--- a/internal/server/backend/match/matchserver_test.go
+++ b/internal/server/backend/match/matchserver_test.go
@@ -406,8 +406,10 @@ func TestMatchingServerPlayerSecondGame(t *testing.T) {
 	liveMatch := matchingServer.LiveMatches()[0]
 	player1.RequestChanAsync <- RequestAsync{Resign: true}
 	response := <-player1.ResponseChanAsync
-	player1.ClientDoneWithMatch()
-	player2.ClientDoneWithMatch()
+	player1.WaitForMatchOver()
+	player2.WaitForMatchOver()
+	player1.Reset()
+	player2.Reset()
 	tries = 0
 	for len(matchingServer.LiveMatches()) == 1 && tries < 10 {
 		time.Sleep(time.Millisecond)

--- a/internal/server/backend/websocket/websocketserver.go
+++ b/internal/server/backend/websocket/websocketserver.go
@@ -68,6 +68,7 @@ func writeLoop(c *websocket.Conn, player *matchserver.Player,
 	err := player.WaitForMatchStart()
 	if err != nil {
 		log.Println("FATAL: Failed to find match")
+		return
 	}
 	ticker := time.NewTicker(pingPeriod)
 	defer ticker.Stop()

--- a/internal/server/backend/websocket/websocketserver.go
+++ b/internal/server/backend/websocket/websocketserver.go
@@ -42,6 +42,10 @@ func makeWebsocketHandler(matchServer *matchserver.MatchingServer,
 		wsHandlerSpan := tracer.StartSpan("WSMatch")
 		defer wsHandlerSpan.Finish()
 		player := gateway.GetSession(w, r)
+		if player == nil {
+			log.Println("No player found for session")
+			return
+		}
 		c, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			log.Println("Upgrade error:", err)
@@ -134,11 +138,14 @@ func readLoop(c *websocket.Conn, matchServer *matchserver.MatchingServer,
 				websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 				log.Printf("Websocketserver read error: %v", err)
 			}
+			/* TODO instead of immediate resignation let the matchserver know
+			that there is no client connected, then matchserver can handle when
+			to time them out
 			if player.GetMatch() != nil && !player.GetMatch().GameOver() {
 				player.RequestChanAsync <- matchserver.RequestAsync{
 					Resign: true,
 				}
-			}
+			}*/
 			close(waitc)
 			readWSSpan.LogFields(opentracinglog.String("readType", "ConnClosed"))
 			readWSSpan.Finish()

--- a/internal/server/backend/websocket/websocketserver.go
+++ b/internal/server/backend/websocket/websocketserver.go
@@ -57,7 +57,7 @@ func makeWebsocketHandler(matchServer *matchserver.MatchingServer,
 		waitc := make(chan struct{})
 		player.ClientConnectToMatch()
 		defer player.ClientDisconnectFromMatch()
-		playerMutex := sync.Mutex{}
+		playerMutex := &sync.Mutex{}
 		go readLoop(c, matchServer, player, wsHandlerSpan, waitc, playerMutex)
 		writeLoop(c, player, wsHandlerSpan, playerMutex)
 		<-waitc
@@ -67,7 +67,7 @@ func makeWebsocketHandler(matchServer *matchserver.MatchingServer,
 }
 
 func writeLoop(c *websocket.Conn, player *matchserver.Player,
-	span opentracing.Span, playerMutex sync.Mutex) {
+	span opentracing.Span, playerMutex *sync.Mutex) {
 	tracer := opentracing.GlobalTracer()
 	err := player.WaitForMatchStart()
 	if err != nil {
@@ -131,7 +131,7 @@ func writeLoop(c *websocket.Conn, player *matchserver.Player,
 
 func readLoop(c *websocket.Conn, matchServer *matchserver.MatchingServer,
 	player *matchserver.Player, span opentracing.Span, waitc chan struct{},
-	playerMutex sync.Mutex) {
+	playerMutex *sync.Mutex) {
 	defer c.Close()
 	tracer := opentracing.GlobalTracer()
 	for {

--- a/internal/server/backend/websocket/websocketserver.go
+++ b/internal/server/backend/websocket/websocketserver.go
@@ -65,14 +65,6 @@ func writeLoop(c *websocket.Conn, player *matchserver.Player,
 	if err != nil {
 		log.Println("FATAL: Failed to find match")
 	}
-	matchedResponse := matchserver.WebsocketResponse{
-		WebsocketResponseType: matchserver.MatchStartT,
-		MatchedResponse: matchserver.MatchedResponse{
-			Color: player.Color(), OpponentName: player.MatchedOpponentName(),
-			MaxTimeMs: player.MatchMaxTimeMs(),
-		},
-	}
-	c.WriteJSON(&matchedResponse)
 	ticker := time.NewTicker(pingPeriod)
 	defer ticker.Stop()
 	for {

--- a/internal/server/backend/websocket/websocketserver.go
+++ b/internal/server/backend/websocket/websocketserver.go
@@ -55,8 +55,10 @@ func makeWebsocketHandler(matchServer *matchserver.MatchingServer,
 		}
 		defer c.Close()
 		waitc := make(chan struct{})
-		player.ClientConnectToMatch()
-		defer player.ClientDisconnectFromMatch()
+		player.ClientConnectToPlayer()
+		defer player.ClientDisconnectFromPlayer()
+		// playerMutex is used to ensure we are not interacting with the player
+		// while resetting it
 		playerMutex := &sync.Mutex{}
 		go readLoop(c, matchServer, player, wsHandlerSpan, waitc, playerMutex)
 		writeLoop(c, player, wsHandlerSpan, playerMutex)

--- a/internal/server/backend/websocket/websocketserver.go
+++ b/internal/server/backend/websocket/websocketserver.go
@@ -58,11 +58,11 @@ func makeWebsocketHandler(matchServer *matchserver.MatchingServer,
 		writeLoop(c, player, wsHandlerSpan)
 		<-waitc
 		log.Println("Websocketserver disconnecting from client")
-		player.ClientDoneWithMatch()
-		/* TODO do we have player reset itself instead
 		if player.GetMatch() != nil && player.GetMatch().GameOver() {
+			log.Println("Websocketserver detects player is over, resetting player")
+			player.WaitForMatchOver()
+			player.Reset()
 		}
-		*/
 	}
 	return http.HandlerFunc(handler)
 }
@@ -148,12 +148,12 @@ func readLoop(c *websocket.Conn, matchServer *matchserver.MatchingServer,
 			/* TODO instead of immediate resignation let the matchserver know
 			that there is no client connected, then matchserver can handle when
 			to time them out
-			*/
 			if player.GetMatch() != nil && !player.GetMatch().GameOver() {
 				player.RequestChanAsync <- matchserver.RequestAsync{
 					Resign: true,
 				}
 			}
+			*/
 			close(waitc)
 			readWSSpan.LogFields(opentracinglog.String("readType", "ConnClosed"))
 			readWSSpan.Finish()

--- a/internal/server/backend/websocket/websocketserver_test.go
+++ b/internal/server/backend/websocket/websocketserver_test.go
@@ -375,20 +375,6 @@ func TestWSRematch(t *testing.T) {
 	if !playerResp.ResponseAsync.GameOver {
 		t.Error("Expected gameover")
 	}
-	white.Close()
-	black.Close()
-	startSession(client, "player1")
-	startSession(client2, "player2")
-	ws, _, err = wsDialer.Dial(u, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ws.Close()
-	ws2, _, err = wsDialer2.Dial(u, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ws2.Close()
 	message = matchserver.WebsocketRequest{
 		WebsocketRequestType: matchserver.RequestAsyncT,
 		RequestAsync:         matchserver.RequestAsync{Match: true},

--- a/internal/server/backend/websocket/websocketserver_test.go
+++ b/internal/server/backend/websocket/websocketserver_test.go
@@ -28,7 +28,7 @@ func init() {
 	exitChan := make(chan bool, 1)
 	close(exitChan)
 	matchingServer.StartMatchServers(10, exitChan)
-	serverSession = httptest.NewServer(http.HandlerFunc(gateway.StartSession))
+	serverSession = httptest.NewServer(http.HandlerFunc(gateway.Session))
 	serverMatchAndPlay = httptest.NewServer(http.Handler(makeWebsocketHandler(&matchingServer)))
 }
 

--- a/internal/server/backend/websocket/websocketserver_test.go
+++ b/internal/server/backend/websocket/websocketserver_test.go
@@ -70,14 +70,14 @@ func TestWSMatch(t *testing.T) {
 	wsResponse2 := matchserver.WebsocketResponse{}
 	ws.ReadJSON(&wsResponse)
 	ws2.ReadJSON(&wsResponse2)
-	if wsResponse.WebsocketResponseType != matchserver.MatchStartT ||
-		wsResponse.MatchedResponse.Color == wsResponse2.MatchedResponse.Color {
+	if wsResponse.WebsocketResponseType != matchserver.ResponseAsyncT ||
+		wsResponse.ResponseAsync.MatchDetails.Color == wsResponse2.ResponseAsync.MatchDetails.Color {
 		t.Error("Expected the two players to have different colors")
 	}
 	black := ws
 	white := ws2
 	whiteName := "player2"
-	if wsResponse.MatchedResponse.Color == model.White {
+	if wsResponse.ResponseAsync.MatchDetails.Color == model.White {
 		black = ws2
 		white = ws
 		whiteName = "player1"
@@ -175,13 +175,13 @@ func TestWSDraw(t *testing.T) {
 	wsResponse2 := matchserver.WebsocketResponse{}
 	ws.ReadJSON(&wsResponse)
 	ws2.ReadJSON(&wsResponse2)
-	if wsResponse.WebsocketResponseType != matchserver.MatchStartT ||
-		wsResponse.MatchedResponse.Color == wsResponse2.MatchedResponse.Color {
+	if wsResponse.WebsocketResponseType != matchserver.ResponseAsyncT ||
+		wsResponse.ResponseAsync.MatchDetails.Color == wsResponse2.ResponseAsync.MatchDetails.Color {
 		t.Error("Expected the two players to have different colors")
 	}
 	black := ws
 	white := ws2
-	if wsResponse.MatchedResponse.Color == model.White {
+	if wsResponse.ResponseAsync.MatchDetails.Color == model.White {
 		black = ws2
 		white = ws
 	}
@@ -267,13 +267,13 @@ func TestWSResign(t *testing.T) {
 	wsResponse2 := matchserver.WebsocketResponse{}
 	ws.ReadJSON(&wsResponse)
 	ws2.ReadJSON(&wsResponse2)
-	if wsResponse.WebsocketResponseType != matchserver.MatchStartT ||
-		wsResponse.MatchedResponse.Color == wsResponse2.MatchedResponse.Color {
+	if wsResponse.WebsocketResponseType != matchserver.ResponseAsyncT ||
+		wsResponse.ResponseAsync.MatchDetails.Color == wsResponse2.ResponseAsync.MatchDetails.Color {
 		t.Error("Expected the two players to have different colors")
 	}
 	black := ws
 	white := ws2
-	if wsResponse.MatchedResponse.Color == model.White {
+	if wsResponse.ResponseAsync.MatchDetails.Color == model.White {
 		black = ws2
 		white = ws
 	}
@@ -356,13 +356,14 @@ func TestWSRematch(t *testing.T) {
 	wsResponse2 := matchserver.WebsocketResponse{}
 	ws.ReadJSON(&wsResponse)
 	ws2.ReadJSON(&wsResponse2)
-	if wsResponse.WebsocketResponseType != matchserver.MatchStartT ||
-		wsResponse.MatchedResponse.Color == wsResponse2.MatchedResponse.Color {
+	if wsResponse.WebsocketResponseType != matchserver.ResponseAsyncT ||
+		wsResponse.ResponseAsync.MatchDetails.Color ==
+			wsResponse2.ResponseAsync.MatchDetails.Color {
 		t.Error("Expected the two players to have different colors")
 	}
 	black := ws
 	white := ws2
-	if wsResponse.MatchedResponse.Color == model.White {
+	if wsResponse.ResponseAsync.MatchDetails.Color == model.White {
 		black = ws2
 		white = ws
 	}
@@ -398,8 +399,9 @@ func TestWSRematch(t *testing.T) {
 	wsResponse2 = matchserver.WebsocketResponse{}
 	ws.ReadJSON(&wsResponse)
 	ws2.ReadJSON(&wsResponse2)
-	if wsResponse.WebsocketResponseType != matchserver.MatchStartT ||
-		wsResponse.MatchedResponse.Color == wsResponse2.MatchedResponse.Color {
+	if wsResponse.WebsocketResponseType != matchserver.ResponseAsyncT ||
+		wsResponse.ResponseAsync.MatchDetails.Color ==
+			wsResponse2.ResponseAsync.MatchDetails.Color {
 		t.Error("Expected the two players to have different colors")
 	}
 }

--- a/internal/server/frontend/gateway.go
+++ b/internal/server/frontend/gateway.go
@@ -176,6 +176,7 @@ func GetSession(w http.ResponseWriter, r *http.Request) *matchserver.Player {
 	return player
 }
 
+// CurrentMatch serializable struct to bring client up to speed
 type CurrentMatch struct {
 	BlackName                   string
 	WhiteName                   string
@@ -195,6 +196,12 @@ type CurrentMatch struct {
 	TurnsSinceCaptureOrPawnMove uint8
 	RequestedDraw               bool
 	RequestedDrawName           string
+}
+
+// CurrentMatchResponse serializable struct to bring client up to speed
+type CurrentMatchResponse struct {
+	Credentials Credentials
+	Match       CurrentMatch
 }
 
 func currentMatchFromMatch(match *matchserver.Match) CurrentMatch {
@@ -223,11 +230,6 @@ func currentMatchFromMatch(match *matchserver.Match) CurrentMatch {
 		RequestedDraw:               requestedDraw,
 		RequestedDrawName:           requestedDrawName,
 	}
-}
-
-type CurrentMatchResponse struct {
-	Credentials Credentials
-	Match       CurrentMatch
 }
 
 // GetCurrentMatch returns the client's username if a valid token is supplied, it

--- a/internal/server/frontend/gateway.go
+++ b/internal/server/frontend/gateway.go
@@ -143,7 +143,6 @@ func GetSession(w http.ResponseWriter, r *http.Request) *matchserver.Player {
 	defer getSessionSpan.Finish()
 	c, err := r.Cookie("session_token")
 	if err != nil {
-		println("GET SESSION ERROR")
 		if err == http.ErrNoCookie {
 			log.Println("session_token is not set")
 			w.WriteHeader(http.StatusUnauthorized)
@@ -155,7 +154,6 @@ func GetSession(w http.ResponseWriter, r *http.Request) *matchserver.Player {
 		return nil
 	}
 	sessionToken := c.Value
-	println("SESSION token: " + sessionToken)
 	getTokenSpan := tracer.StartSpan(
 		"GetToken",
 		opentracing.ChildOf(getSessionSpan.Context()),
@@ -163,12 +161,10 @@ func GetSession(w http.ResponseWriter, r *http.Request) *matchserver.Player {
 	player, err := sessionCache.Get(sessionToken)
 	getTokenSpan.Finish()
 	if err != nil {
-		println("SESSION CACHE ERROR")
 		log.Println("ERROR ", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return nil
 	} else if player == nil {
-		println("PLAYER IS NIL")
 		log.Println("No player found for token ", sessionToken)
 		w.WriteHeader(http.StatusUnauthorized)
 		return nil

--- a/internal/server/frontend/gateway.go
+++ b/internal/server/frontend/gateway.go
@@ -197,6 +197,7 @@ func GetSession(w http.ResponseWriter, r *http.Request) *matchserver.Player {
 type CurrentMatch struct {
 	BlackName                   string
 	WhiteName                   string
+	MaxTimeMs                   int64
 	BlackRemainingTimeMs        int64
 	WhiteRemainingTimeMs        int64
 	Board                       model.SerializableBoard
@@ -236,6 +237,7 @@ func currentMatchFromMatch(match *matchserver.Match) CurrentMatch {
 	return CurrentMatch{
 		BlackName:                   match.PlayerName(model.Black),
 		WhiteName:                   match.PlayerName(model.White),
+		MaxTimeMs:                   match.MaxTimeMs(),
 		BlackRemainingTimeMs:        match.PlayerRemainingTimeMs(model.Black),
 		WhiteRemainingTimeMs:        match.PlayerRemainingTimeMs(model.White),
 		Board:                       match.Game.GetSerializableBoard(),

--- a/internal/server/frontend/gateway_test.go
+++ b/internal/server/frontend/gateway_test.go
@@ -18,13 +18,13 @@ var (
 )
 
 func init() {
-	serverSession = httptest.NewServer(http.HandlerFunc(StartSession))
+	serverSession = httptest.NewServer(http.HandlerFunc(Session))
 	SetQuiet()
 }
 
-func TestStartSession(t *testing.T) {
+func TestSession(t *testing.T) {
 	if debug {
-		fmt.Println("Test StartSession")
+		fmt.Println("Test Session")
 	}
 	credentialsBuf := new(bytes.Buffer)
 	credentials := Credentials{"my_username"}
@@ -45,9 +45,9 @@ func TestStartSession(t *testing.T) {
 	}
 }
 
-func TestStartSessionError(t *testing.T) {
+func TestSessionError(t *testing.T) {
 	if debug {
-		fmt.Println("Test StartSessionError")
+		fmt.Println("Test SessionError")
 	}
 	resp, err := http.Post(serverSession.URL, "application/json", bytes.NewBuffer([]byte("error")))
 	if err != nil {
@@ -64,9 +64,9 @@ func TestStartSessionError(t *testing.T) {
 	}
 }
 
-func TestStartSessionNoUsername(t *testing.T) {
+func TestSessionNoUsername(t *testing.T) {
 	if debug {
-		fmt.Println("Test StartSessionNoUsername")
+		fmt.Println("Test SessionNoUsername")
 	}
 	requestBody, _ := json.Marshal(map[string]string{
 		"not_username": "my_username",

--- a/internal/server/frontend/gateway_test.go
+++ b/internal/server/frontend/gateway_test.go
@@ -22,7 +22,7 @@ func init() {
 	SetQuiet()
 }
 
-func TestHTTPServerStartSession(t *testing.T) {
+func TestStartSession(t *testing.T) {
 	if debug {
 		fmt.Println("Test StartSession")
 	}
@@ -45,7 +45,7 @@ func TestHTTPServerStartSession(t *testing.T) {
 	}
 }
 
-func TestHTTPServerStartSessionError(t *testing.T) {
+func TestStartSessionError(t *testing.T) {
 	if debug {
 		fmt.Println("Test StartSessionError")
 	}
@@ -64,7 +64,7 @@ func TestHTTPServerStartSessionError(t *testing.T) {
 	}
 }
 
-func TestHTTPServerStartSessionNoUsername(t *testing.T) {
+func TestStartSessionNoUsername(t *testing.T) {
 	if debug {
 		fmt.Println("Test StartSessionNoUsername")
 	}


### PR DESCRIPTION
* Redesign websocketServer to handle reconnects
* Implement GET /session
* Implement reconnect logic in the web client
* Make a serializable version of game state
* Test ws reconnect and add a lock to player to enforce one client connection at a time
* Websocket connections can persist through multiple matches now